### PR TITLE
[fuzz] a patchable bug filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,4 @@ jobs:
           python nnsmith/cli/model_exec.py model.type=tensorflow backend.type=xla model.path=nnsmith_output/model/
       - name: Test CLI [fuzz]
         run: |
-          yes | python nnsmith/cli/fuzz.py fuzz.time=10s fuzz.root=fuzz_report model.type=tensorflow backend.type=xla
+          yes | python nnsmith/cli/fuzz.py fuzz.time=10s fuzz.root=fuzz_report model.type=tensorflow backend.type=xla filter.type="[nan,inf,test_fn,test_cls]" filter.patch=./tests/mock/filter_patch.py

--- a/doc/concept.md
+++ b/doc/concept.md
@@ -12,7 +12,7 @@
     - `"system"`: like `"tvm-gpu"` and `"ort-cpu"`
     - `"version"`: a version string hooked from `${SystemPackage}.__version__`
     - `"symptom"`: `"crash"` or `"inconsistency"`
-    - `"trigger_hash"` (optional): a git hash that can trigger this bug.
+    - `"version_id"` (optional): an identifier of the system's version (e.g., git hash or version strings)
 
 ## Abstract Operators (AO)
 

--- a/nnsmith/cli/model_exec.py
+++ b/nnsmith/cli/model_exec.py
@@ -12,6 +12,7 @@ import os
 import pickle
 import random
 from pathlib import Path
+from typing import List
 
 import hydra
 from omegaconf import DictConfig, ListConfig
@@ -27,6 +28,7 @@ def verify_testcase(
     factory: BackendFactory,
     testcase: TestCase,
     output_dir: os.PathLike,
+    filters: List = None,
     supress_succ=True,
 ) -> bool:
     def check_result(bug_report_or, odir, msg=None) -> bool:  # succ?
@@ -37,6 +39,11 @@ def verify_testcase(
             return True
         else:
             bug_report = bug_report_or
+
+            for f in filters:
+                if f(bug_report):  # filter: no log & dump. but still a bug.
+                    return False
+
             EXEC_LOG.warning("[FAIL] ")
             EXEC_LOG.warning(bug_report.log)
             if odir is not None:

--- a/nnsmith/config/main.yaml
+++ b/nnsmith/config/main.yaml
@@ -50,6 +50,10 @@ fuzz:
   root: "???"
   seed: null
 
+filter:
+  type: []
+  patch: []
+
 cmp:
   equal_nan: true    # skip regarding it as a bug if with fp exception values.
 

--- a/nnsmith/filter.py
+++ b/nnsmith/filter.py
@@ -1,0 +1,73 @@
+from inspect import signature
+from typing import Set, Type
+
+from nnsmith.materialize import BugReport, Stage, Symptom
+
+FILTERS = {}
+
+
+class filter:
+    def __init__(self, name):
+        self.name = name
+
+    def __call__(self, fn_or_cls):
+        assert self.name not in FILTERS, f"Filter {self.name} already exists."
+        if isinstance(fn_or_cls, Type):  # Class checks
+            assert not signature(
+                fn_or_cls
+            ).parameters, f"filter class {fn_or_cls.__name__} (aka {self.name}) should not have any parameters."
+            caller_sig = signature(fn_or_cls.__call__).parameters
+            assert (
+                caller_sig["self"] and len(caller_sig) == 2
+            ), f"filter class {fn_or_cls.__name__} (aka {self.name}) should implement __call__(self, report: BugReport)."
+        elif callable(fn_or_cls):  # Function checks
+            caller_sig = signature(fn_or_cls).parameters
+            assert (
+                len(caller_sig) == 1
+            ), f"filter function {fn_or_cls.__name__} (aka {self.name}) should implement __call__(report: BugReport)."
+        else:
+            raise ValueError(
+                f"filter {fn_or_cls} (aka {self.name}) should be a class or function."
+            )
+
+        FILTERS[self.name] = fn_or_cls
+        return fn_or_cls
+
+
+@filter("nan")
+def filter_nan(report: BugReport) -> bool:  # True means filter;
+    if report.symptom != Symptom.INCONSISTENCY or report.stage != Stage.VERIFICATION:
+        return False
+
+    # numpy.assert_allclose style.
+    # TODO(ganler): can we use more well-formed checking? say directly checking the results?
+    return "nan location mismatch" in report.log
+
+
+@filter("inf")
+def filter_inf(report: BugReport) -> bool:
+    if report.symptom != Symptom.INCONSISTENCY or report.stage != Stage.VERIFICATION:
+        return False
+
+    # numpy.assert_allclose style.
+    return "inf" in report.log.replace("Max relative difference: inf", "")
+
+
+@filter("dup")  # duplicate
+class FilterDup:
+    def __init__(self):
+        self.seen: Set[int] = set()
+
+    def __call__(self, report: BugReport) -> bool:
+        if report.symptom == Symptom.SEGFAULT:
+            return False  # don't filter segfaults
+
+        str_hash = hash(report.log)
+        if str_hash in self.seen:
+            return True
+
+        self.seen.add(str_hash)
+        return False
+
+
+# You can patch your own filters!

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -304,7 +304,7 @@ class BugReport(ABC):
         stage: Stage,
         system: str,
         version: str = None,
-        trigger_hash: str = None,
+        version_id: str = None,
         log: str = None,
     ):
         self.testcase = testcase
@@ -312,7 +312,7 @@ class BugReport(ABC):
         self.system = system
         self.stage = stage
         self.version = version
-        self.trigger_hash = trigger_hash
+        self.version_id = version_id
         self.log = log
 
     @staticmethod
@@ -341,7 +341,7 @@ class BugReport(ABC):
                     "symptom": self.symptom.value,
                     "stage": self.stage.value,
                     "version": self.version,
-                    "trigger_hash": self.trigger_hash,
+                    "version_id": self.version_id,
                 },
                 f,
             )
@@ -352,7 +352,7 @@ class BugReport(ABC):
         symptom = None
         stage = None
         version = None
-        trigger_hash = None
+        version_id = None
         system = None
 
         assert allow_partial or os.path.exists(
@@ -367,7 +367,7 @@ class BugReport(ABC):
             symptom = Symptom(meta["symptom"])
             stage = Stage(meta["stage"])
             version = meta["version"]
-            trigger_hash = meta["trigger_hash"]
+            version_id = meta["version_id"]
 
         testcase = TestCase.load(model_type, root_folder, allow_partial)
 
@@ -376,4 +376,4 @@ class BugReport(ABC):
             with open(os.path.join(root_folder, BugReport.error_msg_name()), "r") as f:
                 log = f.read()
 
-        return BugReport(testcase, symptom, stage, system, version, trigger_hash, log)
+        return BugReport(testcase, symptom, stage, system, version, version_id, log)

--- a/tests/mock/filter_patch.py
+++ b/tests/mock/filter_patch.py
@@ -1,0 +1,13 @@
+from nnsmith.filter import filter
+from nnsmith.materialize import BugReport
+
+
+@filter("test_fn")
+def filter_fn(report: BugReport):
+    return False  # Won't filter anything.
+
+
+@filter("test_cls")
+class FilterCls:
+    def __call__(self, report: BugReport) -> bool:
+        return False  # Won't filter anything.


### PR DESCRIPTION
- defining "a filtered bug report":
   - a bug report will not be logged or dumped;
   - nevertheless, it is still a bug -- it's just the user wants to ignore it for some reason.
- native support: nan, inf, dup (duplicate filter with string hash)
   - `+` fuzz args: `filter.type="[nan,inf]"`
- bring your own filter: 
   - implement a callable to `(report: BugReport) -> bool` where True means filtering the bug.
   - put the file to `path/to/patch.py`
   - decorate it with `nnsmith.filter.filter("filter_name")` (note `nan`, `inf`, `dup` are taken)
   - load it at runtime: `+` fuzz args `  filter.type="[nan,inf,filter_name]" filter.patch=/path/to/patch.py`
- tested patching with a dummy patch (`tests/mock/filter_patch.py`) in the end-to-end fuzzing script in the ci.