### PR TITLE
Improving filter for undef behavior and vulops

### DIFF
--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -129,7 +129,9 @@ class FuzzingLoop:
             model_cfg["type"], backend_target=cfg["backend"]["target"]
         )
         self.ModelType.add_seed_setter()
-        self.opset = auto_opset(self.ModelType, self.factory)
+        self.opset = auto_opset(
+            self.ModelType, self.factory, vulops=cfg["mgen"]["vulops"]
+        )
 
         seed = cfg["fuzz"]["seed"] or random.getrandbits(32)
         set_seed(seed)

--- a/nnsmith/cli/model_gen.py
+++ b/nnsmith/cli/model_gen.py
@@ -38,7 +38,7 @@ def main(cfg: DictConfig):
         factory = None
 
     gen = random_model_gen(
-        opset=auto_opset(ModelType, factory),
+        opset=auto_opset(ModelType, factory, vulops=mgen_cfg["vulops"]),
         init_rank=mgen_cfg["init_rank"],
         seed=seed,
         max_nodes=mgen_cfg["max_nodes"],

--- a/nnsmith/config/main.yaml
+++ b/nnsmith/config/main.yaml
@@ -29,6 +29,7 @@ mgen: # model gen.
   init_rank: 4
   max_nodes: 5
   timeout_ms: 50000
+  vulops: False
   save: "nnsmith_output"
   seed: null
 

--- a/nnsmith/filter.py
+++ b/nnsmith/filter.py
@@ -42,7 +42,11 @@ def filter_nan(report: BugReport) -> bool:  # True means filter;
 
     # numpy.assert_allclose style.
     # TODO(ganler): can we use more well-formed checking? say directly checking the results?
-    return "nan location mismatch" in report.log
+    return (
+        "nan location mismatch" in report.log
+        or "-9223372036854775808" in report.log  # tf.cast(nan, int) is UB.
+        or "-2147483648" in report.log
+    )
 
 
 @filter("inf")

--- a/nnsmith/narrow_spec.py
+++ b/nnsmith/narrow_spec.py
@@ -252,12 +252,16 @@ def auto_opconfig(
         return opset
 
 
-def auto_opset(model_cls: Type[Model], factory: Optional[BackendFactory] = None):
+def auto_opset(
+    model_cls: Type[Model],
+    factory: Optional[BackendFactory] = None,
+    vulops: bool = False,
+) -> List[Type[AbsOpBase]]:
     # None means only test model exportation.
     topset_config = auto_opconfig(model_cls, factory)
     opset = []
     for op in model_cls.operators():
-        if op.name() not in topset_config:
+        if op.name() not in topset_config or (vulops == False and op.limit_domain):
             continue
         op.in_dtypes = topset_config[op.name()].in_dtypes
         op.out_dtypes = topset_config[op.name()].out_dtypes


### PR DESCRIPTION
- nan filter will filter `-9223372036854775808` (int64::min()) and `-2147483648` (int32::min()) to route the UD in tensorflow.
- `mgen.vulops` to allow or disable (default) vulnerable operators.