### PR TITLE
[util] save intermediate tests & fallback to `fuzz.crash_safe=false`

### DIFF
--- a/doc/known-issues.md
+++ b/doc/known-issues.md
@@ -1,6 +1,6 @@
 ## Incompatibility of TensorFlow-GPU over fork-based crash safty
 
-Currently we enabled `fuzz.crash_safe=true` by default where we run the compilation & execution in a forked process as a sandbox to catch crash and timeout. However, CUDA runtime is not compatible with fork. In tensorflow, the symptom is crash in forked subprocess:
+`fuzz.crash_safe=true` allows running compilation & execution in a forked process as a sandbox to catch crash and timeout. However, CUDA runtime is not compatible with fork. In tensorflow, the symptom is crash in forked subprocess:
 
 ```txt
 F tensorflow/stream_executor/cuda/cuda_driver.cc:219] Failed setting context: CUDA_ERROR_NOT_INITIALIZED: initialization error

--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -219,8 +219,10 @@ class FuzzingLoop:
                 FUZZ_LOG.warning(f"Failed model seed: {seed}")
 
             if self.save_test:
-                testcase.dump(os.path.join(self.save_test,
-                              f"{time.time() - start_time:.3f}"))
+                testcase_dir = os.path.join(self.save_test,
+                                            f"{time.time() - start_time:.3f}")
+                mkdir(testcase_dir)
+                testcase.dump(testcase_dir)
             self.status.n_testcases += 1
 
 

--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -95,7 +95,8 @@ class FuzzingLoop:
                 assert os.path.isfile(
                     f
                 ), "filter.patch must be a list of file locations."
-                assert "@filter(" in open(f).read(), f"No filter found in the {f}."
+                assert "@filter(" in open(
+                    f).read(), f"No filter found in the {f}."
                 spec = spec_from_file_location("module.name", f)
                 spec.loader.exec_module(module_from_spec(spec))
                 FUZZ_LOG.info(f"Imported filter patch: {f}")
@@ -147,6 +148,12 @@ class FuzzingLoop:
         assert isinstance(
             self.timeout_s, int
         ), "`fuzz.time` must be an integer (with `s` (default), `m`/`min`, or `h`/`hr`)."
+
+        self.save_test = cfg["fuzz"]["save_test"]
+        if isinstance(self.save_test, str):  # path of root dir.
+            FUZZ_LOG.log(
+                f"Saving all intermediate testcases to {self.save_test}")
+            mkdir(self.save_test)
 
     def make_testcase(self, seed) -> TestCase:
         mgen_cfg = self.cfg["mgen"]
@@ -210,6 +217,10 @@ class FuzzingLoop:
 
             if not self.validate_and_report(testcase):
                 FUZZ_LOG.warning(f"Failed model seed: {seed}")
+
+            if self.save_test:
+                testcase.dump(os.path.join(self.save_test,
+                              f"{time.time() - start_time:.3f}"))
             self.status.n_testcases += 1
 
 

--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -151,7 +151,7 @@ class FuzzingLoop:
 
         self.save_test = cfg["fuzz"]["save_test"]
         if isinstance(self.save_test, str):  # path of root dir.
-            FUZZ_LOG.log(
+            FUZZ_LOG.info(
                 f"Saving all intermediate testcases to {self.save_test}")
             mkdir(self.save_test)
 

--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -95,8 +95,7 @@ class FuzzingLoop:
                 assert os.path.isfile(
                     f
                 ), "filter.patch must be a list of file locations."
-                assert "@filter(" in open(
-                    f).read(), f"No filter found in the {f}."
+                assert "@filter(" in open(f).read(), f"No filter found in the {f}."
                 spec = spec_from_file_location("module.name", f)
                 spec.loader.exec_module(module_from_spec(spec))
                 FUZZ_LOG.info(f"Imported filter patch: {f}")
@@ -151,8 +150,7 @@ class FuzzingLoop:
 
         self.save_test = cfg["fuzz"]["save_test"]
         if isinstance(self.save_test, str):  # path of root dir.
-            FUZZ_LOG.info(
-                f"Saving all intermediate testcases to {self.save_test}")
+            FUZZ_LOG.info(f"Saving all intermediate testcases to {self.save_test}")
             mkdir(self.save_test)
 
     def make_testcase(self, seed) -> TestCase:
@@ -219,8 +217,9 @@ class FuzzingLoop:
                 FUZZ_LOG.warning(f"Failed model seed: {seed}")
 
             if self.save_test:
-                testcase_dir = os.path.join(self.save_test,
-                                            f"{time.time() - start_time:.3f}")
+                testcase_dir = os.path.join(
+                    self.save_test, f"{time.time() - start_time:.3f}"
+                )
                 mkdir(testcase_dir)
                 testcase.dump(testcase_dir)
             self.status.n_testcases += 1

--- a/nnsmith/config/main.yaml
+++ b/nnsmith/config/main.yaml
@@ -50,17 +50,18 @@ fuzz:
   time: 14400
   root: "???"
   seed: null
-  crash_safe: true
-  test_timeout: null # second.
+  crash_safe: false
+  test_timeout: null
+  save_test: null
 
 filter:
   type: []
   patch: []
 
 cmp:
-  equal_nan: true    # skip regarding it as a bug if with fp exception values.
+  equal_nan: true # skip regarding it as a bug if with fp exception values.
 
-  raw_input: null    # path to raw input data (Dict[str, np.ndarray])
+  raw_input: null # path to raw input data (Dict[str, np.ndarray])
 
   oracle: "auto"
   # "auto": use `oracle.pkl` in local path;

--- a/nnsmith/materialize/torch/forward.py
+++ b/nnsmith/materialize/torch/forward.py
@@ -21,10 +21,17 @@ operator_impl = partial(framework_operator_impl, TORCH_REALIZABLE_OPS, ALL_TORCH
 
 @operator_impl(Constant)
 def forward_fn(op: Constant):
-    data = torch.randn(op.abs_tensor.shape).to(op.abs_tensor.dtype.torch())
-    return lambda: torch.nn.parameter.Parameter(
-        data, requires_grad=data.is_floating_point()
-    )
+    class ConstFn(torch.nn.Module):
+        def __init__(self, data) -> None:
+            super().__init__()
+            self.data = torch.nn.parameter.Parameter(
+                data, requires_grad=data.is_floating_point()
+            )
+
+        def forward(self):
+            return self.data
+
+    return ConstFn(torch.randn(op.abs_tensor.shape).to(op.abs_tensor.dtype.torch()))
 
 
 @operator_impl(ReLU)


### PR DESCRIPTION
- Allow saving intermediate tests
- Fallback to in-process execution -- fork-based crash safety does not work for TF-GPU & Torch-JIT which needs to be further addressed by adding another crash safety mechanism -- isolated executor in ``client-server-like'' pattern.