### PR TITLE
Improve versioning of nnsmith/backend/model

### DIFF
--- a/nnsmith/__init__.py
+++ b/nnsmith/__init__.py
@@ -1,4 +1,4 @@
 try:
     from nnsmith._version import __version__, __version_tuple__
 except ImportError:
-    pass
+    __version__ = "local-dev"

--- a/nnsmith/backends/factory.py
+++ b/nnsmith/backends/factory.py
@@ -30,6 +30,10 @@ class BackendFactory(ABC):
     def system_name(self) -> str:
         pass
 
+    @property
+    def version(self) -> str:
+        return "unknown"
+
     def __str__(self) -> str:
         return f"{self.system_name} ({self.target} opt: {self.optmax})"
 
@@ -76,6 +80,7 @@ class BackendFactory(ABC):
                 symptom=Symptom.EXCEPTION,
                 stage=Stage.COMPILATION,
                 log=traceback.format_exc(),
+                version=self.version,
             )
 
     def checked_exec(
@@ -99,6 +104,7 @@ class BackendFactory(ABC):
                 symptom=Symptom.EXCEPTION,
                 stage=Stage.EXECUTION,
                 log=traceback.format_exc(),
+                version=self.version,
             )
 
     def checked_compile_and_exec(
@@ -169,6 +175,7 @@ class BackendFactory(ABC):
                     symptom=Symptom.TIMEOUT,
                     stage=shared_dict["stage"],
                     log=f"Timeout after {timeout} seconds.",
+                    version=self.version,
                 )
 
             if shared_dict["output"] is not None:
@@ -187,6 +194,7 @@ class BackendFactory(ABC):
                     symptom=Symptom.SEGFAULT,
                     stage=shared_dict["stage"],
                     log=f"Process crashed with exit code: {p.exitcode}",
+                    version=self.version,
                 )
             else:
                 return BugReport(
@@ -195,6 +203,7 @@ class BackendFactory(ABC):
                     symptom=shared_dict["symptom"],
                     stage=shared_dict["stage"],
                     log=shared_dict["log"],
+                    version=self.version,
                 )
 
     def verify_results(
@@ -215,6 +224,7 @@ class BackendFactory(ABC):
                 symptom=Symptom.INCONSISTENCY,
                 stage=Stage.VERIFICATION,
                 log=traceback.format_exc(),
+                version=self.version,
             )
 
     def verify_testcase(
@@ -265,6 +275,7 @@ class BackendFactory(ABC):
                 symptom=Symptom.EXCEPTION,
                 stage=Stage.COMPILATION,
                 log=traceback.format_exc(),
+                version=self.version,
             )
 
         if not input:
@@ -282,6 +293,7 @@ class BackendFactory(ABC):
                 symptom=Symptom.EXCEPTION,
                 stage=Stage.EXECUTION,
                 log=traceback.format_exc(),
+                version=self.version,
             )
 
         return TestCase(

--- a/nnsmith/backends/iree.py
+++ b/nnsmith/backends/iree.py
@@ -4,6 +4,7 @@ import iree.compiler.tf
 import iree.runtime
 import numpy as np
 import tensorflow as tf
+from importlib_metadata import version
 from multipledispatch import dispatch
 
 from nnsmith.backends.factory import BackendCallable, BackendFactory
@@ -37,6 +38,10 @@ class IREEFactory(BackendFactory):
     @property
     def system_name(self) -> str:
         return "iree"
+
+    @property
+    def version(self) -> str:
+        return version("iree-compiler")
 
     @dispatch(TFModel)
     def make_backend(self, model: TFModel) -> BackendCallable:

--- a/nnsmith/backends/onnxruntime.py
+++ b/nnsmith/backends/onnxruntime.py
@@ -38,6 +38,10 @@ class ORTFactory(BackendFactory):
     def system_name(self) -> str:
         return "onnxruntime"
 
+    @property
+    def version(self) -> str:
+        return ort.__version__
+
     @dispatch(ONNXModel)
     def make_backend(
         self,

--- a/nnsmith/backends/tensorrt.py
+++ b/nnsmith/backends/tensorrt.py
@@ -39,6 +39,10 @@ class TRTFactory(BackendFactory):
     def system_name(self) -> str:
         return "tensorrt"
 
+    @property
+    def version(self) -> str:
+        return trt.__version__
+
     @dispatch(ONNXModel)
     def make_backend(self, model: ONNXModel):
         import pycuda.autoinit

--- a/nnsmith/backends/tflite.py
+++ b/nnsmith/backends/tflite.py
@@ -38,6 +38,10 @@ class TFLiteFactory(BackendFactory):
     def system_name(self) -> str:
         return "tflite"
 
+    @property
+    def version(self) -> str:
+        return tf.__version__
+
     @dispatch(TFModel)
     def make_backend(
         self,

--- a/nnsmith/backends/tvm.py
+++ b/nnsmith/backends/tvm.py
@@ -34,19 +34,20 @@ class TVMFactory(BackendFactory):
             assert (
                 target in tvm_possible_targets
             ), f"Unknown target {target}. Possible targets are {tvm_possible_targets}"
-            self.target = tvm.target.Target("cuda")
+            self.target = tvm.target.Target(target)
 
         self.executor_mode = executor
 
     def get_device(self):
-        if (
-            self.target.export()["kind"] == "cuda"
-            or self.target.export()["kind"] == "nvptx"
-        ):
+        dev_cand = self.target.export()["keys"]
+        assert len(dev_cand) > 0, f"No viable device found for {self.target}"
+        if "cuda" in dev_cand:
             return tvm.cuda()
-        if self.target.export()["kind"] == "rocm":
+        if "rocm" in dev_cand:
             return tvm.rocm()
-        return tvm.cpu()
+        if "cpu" in dev_cand:
+            return tvm.cpu()
+        return tvm.device(dev_cand[0])
 
     @property
     def system_name(self) -> str:

--- a/nnsmith/backends/tvm.py
+++ b/nnsmith/backends/tvm.py
@@ -84,3 +84,7 @@ class TVMFactory(BackendFactory):
             return dict(zip(model.output_like.keys(), output))
 
         return closure
+
+    @property
+    def version(self) -> str:
+        return tvm.__version__

--- a/nnsmith/backends/tvm.py
+++ b/nnsmith/backends/tvm.py
@@ -28,19 +28,19 @@ class TVMFactory(BackendFactory):
         # inconsistency is allowed and outputs for UB-input may differ.
         self.opt_level = 4 if optmax else 0
         if target == "cpu":
-            self.target = tvm.target.Target("llvm")
+            self.tvm_target = tvm.target.Target("llvm")
         else:
             tvm_possible_targets = tvm.target.Target.list_kinds()
             assert (
                 target in tvm_possible_targets
             ), f"Unknown target {target}. Possible targets are {tvm_possible_targets}"
-            self.target = tvm.target.Target(target)
+            self.tvm_target = tvm.target.Target(target)
 
         self.executor_mode = executor
 
     def get_device(self):
-        dev_cand = self.target.export()["keys"]
-        assert len(dev_cand) > 0, f"No viable device found for {self.target}"
+        dev_cand = self.tvm_target.export()["keys"]
+        assert len(dev_cand) > 0, f"No viable device found for {self.tvm_target}"
         if "cuda" in dev_cand:
             return tvm.cuda()
         if "rocm" in dev_cand:
@@ -75,7 +75,7 @@ class TVMFactory(BackendFactory):
 
         with tvm.transform.PassContext(opt_level=self.opt_level):
             executor = relay.build_module.create_executor(
-                self.executor_mode, mod, self.get_device(), self.target, params
+                self.executor_mode, mod, self.get_device(), self.tvm_target, params
             ).evaluate()
 
         def closure(inputs):

--- a/nnsmith/backends/xla.py
+++ b/nnsmith/backends/xla.py
@@ -29,6 +29,10 @@ class XLAFactory(BackendFactory):
     def system_name(self) -> str:
         return "xla"
 
+    @property
+    def version(self) -> str:
+        return tf.__version__
+
     @dispatch(TFModel)
     def make_backend(self, model: TFModel) -> BackendCallable:
         with self.device, EagerModeCtx(False):

--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -206,7 +206,7 @@ class FuzzingLoop:
                 raise e  # propagate internal errors
             except Exception:
                 FUZZ_LOG.error(
-                    f"`make_testcase` failed. It could be a NNSmith bug or Generator bug (e.g., {self.cfg['model']['type']})."
+                    f"`make_testcase` failed with seed {seed}. It can be NNSmith or Generator ({self.cfg['model']['type']}) bug."
                 )
                 FUZZ_LOG.error(traceback.format_exc())
                 continue

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -196,6 +196,10 @@ class Model(ABC):
     def operators() -> List[Type[AbsOpBase]]:
         pass
 
+    @property
+    def version(self) -> str:
+        return "unknown"
+
     @staticmethod
     def name_prefix() -> str:
         return "model"

--- a/nnsmith/materialize/onnx/__init__.py
+++ b/nnsmith/materialize/onnx/__init__.py
@@ -157,6 +157,10 @@ class ONNXModel(TorchModel):
         self.full_input_like = None
         self.onnx_model = None
 
+    @property
+    def version(self) -> str:
+        return f"onnx{onnx.__version__}-torch{torch.__version__}"
+
     def _mask_outputs(self) -> Dict[str, AbsTensor]:
         assert (
             self.torch_model is not None

--- a/nnsmith/materialize/tensorflow/__init__.py
+++ b/nnsmith/materialize/tensorflow/__init__.py
@@ -86,6 +86,10 @@ class TFModel(Model, ABC):  # Don't directly instantiate this class
         return cls(schedule)
 
     @property
+    def version(self) -> str:
+        return tf.__version__
+
+    @property
     def native_model(self) -> TFNet:
         return self.net
 

--- a/nnsmith/materialize/torch/__init__.py
+++ b/nnsmith/materialize/torch/__init__.py
@@ -18,6 +18,10 @@ class TorchModel(Model):
         self.torch_model: SymbolNet = None
         self.sat_inputs = None
 
+    @property
+    def version(self) -> str:
+        return torch.__version__
+
     @classmethod
     def from_schedule(cls, schedule: Schedule, **kwargs) -> "TorchModel":
         ret = cls()

--- a/nnsmith/narrow_spec.py
+++ b/nnsmith/narrow_spec.py
@@ -28,6 +28,7 @@ import z3
 from appdirs import user_cache_dir
 from omegaconf import OmegaConf
 
+from nnsmith import __version__
 from nnsmith.abstract.dtype import DType
 from nnsmith.abstract.extension import BACKEND_REQUIRES
 from nnsmith.abstract.op import AbsOpBase, AbsTensor, Constant, Input, concretize_op
@@ -35,13 +36,15 @@ from nnsmith.backends import BackendFactory
 from nnsmith.logging import DTEST_LOG
 from nnsmith.materialize import Instruction, Model, Schedule, TestCase
 
-NNSMITH_CACHE_DIR = user_cache_dir("nnsmith")
+NNSMITH_CACHE_DIR = user_cache_dir(f"nnsmith-{__version__}")
 
 
 def get_cache_name(model_cls: Type[Model], factory: BackendFactory) -> str:
     if factory is None:
         return f"{model_cls.__name__}_exportable"
-    return f"{model_cls.__name__}_{factory.system_name}_{factory.target}"
+    return (
+        f"{model_cls.__name__}_{factory.system_name}_{factory.version}_{factory.target}"
+    )
 
 
 @dataclass


### PR DESCRIPTION
- Put a `version` property for `Model` and `BackendFactory`;
- Make local nnsmith's version as `local-dev`;

Other:
- tvm backend's target as user-passed string instead of `tvm.target.Target` for cache file name readability;
- Make device placement more explicit by using `tvm.target.Target().export()["keys"]`;