### PR TITLE
Upstream sharpened GraphIR

### DIFF
--- a/nnsmith/abstract/dtype.py
+++ b/nnsmith/abstract/dtype.py
@@ -9,6 +9,7 @@ class DType(Enum):
     float16 = "float16"
     float32 = "float32"
     float64 = "float64"
+    uint8 = "uint8"  # Support quantized models.
     int8 = "int8"
     int16 = "int16"
     int32 = "int32"
@@ -30,6 +31,7 @@ class DType(Enum):
             DType.float16: "f16",
             DType.float32: "f32",
             DType.float64: "f64",
+            DType.uint8: "u8",
             DType.int8: "i8",
             DType.int16: "i16",
             DType.int32: "i32",
@@ -49,6 +51,7 @@ class DType(Enum):
             "f16": DType.float16,
             "f32": DType.float32,
             "f64": DType.float64,
+            "u8": DType.uint8,
             "i8": DType.int8,
             "i32": DType.int32,
             "i64": DType.int64,
@@ -69,6 +72,7 @@ class DType(Enum):
             DType.float16: np.float16,
             DType.float32: np.float32,
             DType.float64: np.float64,
+            DType.uint8: np.uint8,
             DType.int8: np.int8,
             DType.int16: np.int16,
             DType.int32: np.int32,
@@ -86,6 +90,7 @@ class DType(Enum):
             DType.float16: torch.float16,
             DType.float32: torch.float32,
             DType.float64: torch.float64,
+            DType.uint8: torch.uint8,
             DType.int8: torch.int8,
             DType.int16: torch.int16,
             DType.int32: torch.int32,
@@ -103,6 +108,7 @@ class DType(Enum):
             torch.float16: DType.float16,
             torch.float32: DType.float32,
             torch.float64: DType.float64,
+            torch.uint8: DType.uint8,
             torch.int8: DType.int8,
             torch.int16: DType.int16,
             torch.int32: DType.int32,
@@ -119,6 +125,7 @@ class DType(Enum):
             DType.float16: tf.float16,
             DType.float32: tf.float32,
             DType.float64: tf.float64,
+            DType.uint8: tf.uint8,
             DType.int8: tf.int8,
             DType.int16: tf.int16,
             DType.int32: tf.int32,
@@ -136,6 +143,7 @@ class DType(Enum):
             tf.float16: DType.float16,
             tf.float32: DType.float32,
             tf.float64: DType.float64,
+            tf.uint8: DType.uint8,
             tf.int8: DType.int8,
             tf.int16: DType.int16,
             tf.int32: DType.int32,

--- a/nnsmith/abstract/tensor.py
+++ b/nnsmith/abstract/tensor.py
@@ -25,8 +25,21 @@ class AbsTensor:
     def __repr__(self):
         return f"AbsTensor<{self.dtype.short()}>{str(self.shape)}"
 
-    def __eq__(self, other):
+    def weak_compare(self, other: "AbsTensor") -> bool:
+        if self.dtype != other.dtype or self.ndims != other.ndims:
+            return False
+        for l, r in zip(self.shape, other.shape):
+            if isinstance(l, z3.ExprRef) or isinstance(r, z3.ExprRef):
+                continue
+            if l != r:
+                return False
+        return True
+
+    def strong_compare(self, other: "AbsTensor") -> bool:
         return self.shape == other.shape and self.dtype == other.dtype
+
+    def __eq__(self, other: "AbsTensor") -> bool:
+        return self.strong_compare(other)
 
     def gt_zero(self):
         ret = []

--- a/nnsmith/backends/factory.py
+++ b/nnsmith/backends/factory.py
@@ -1,5 +1,4 @@
 import multiprocessing as mp
-import os
 import sys
 import traceback
 from abc import ABC, abstractmethod
@@ -86,7 +85,7 @@ class BackendFactory(ABC):
     def checked_exec(
         self, executable: BackendCallable, testcase: TestCase
     ) -> Union[Dict[str, np.ndarray], BugReport]:
-        input = testcase.oracle.input
+        input = None if testcase.oracle is None else testcase.oracle.input
         if input is None:
             input = self.make_random_input(testcase.model.input_like)
             testcase = TestCase(
@@ -247,7 +246,7 @@ class BackendFactory(ABC):
         if isinstance(output, BugReport):
             return output
 
-        if testcase.oracle.output is not None:
+        if testcase.oracle is not None and testcase.oracle.output is not None:
             return self.verify_results(output, testcase, equal_nan=equal_nan)
 
         return None

--- a/nnsmith/graph_gen.py
+++ b/nnsmith/graph_gen.py
@@ -404,9 +404,9 @@ class SimpleGenerator:
                 nid = self.get_new_node_id()
                 shape_idx = len(self.tensor_dataflow)
                 self.tensor_dataflow.append(
-                    TensorCtx(op_id=nid, type=input_node.out_shape, output_idx=0)
+                    TensorCtx(op_id=nid, type=input_node.ttype, output_idx=0)
                 )
-                self.dim2shape_idx.setdefault(input_node.out_shape.ndims, []).append(
+                self.dim2shape_idx.setdefault(input_node.ttype.ndims, []).append(
                     shape_idx
                 )
                 self.abstract_graph.add_node(
@@ -647,17 +647,17 @@ class SimpleGenerator:
 
 class PureSymbolGen(SimpleGenerator):
     def insert_init_ph_node(self, ph: Placeholder) -> Placeholder:
-        self.forward_insert_node(ph, [], oshapes=[ph.out_shape])
+        self.forward_insert_node(ph, [], oshapes=[ph.ttype])
 
-        for c in ph.out_shape.gt_zero():
+        for c in ph.ttype.gt_zero():
             self.solver.add(c)
 
         if self.limnf:
             if NNSMITH_LIMNF_V == "0":
-                self.n_floats = nnsmith_add(self.n_floats, ph.out_shape.nelement())
+                self.n_floats = nnsmith_add(self.n_floats, ph.ttype.nelement())
             elif NNSMITH_LIMNF_V == "1":
                 self.n_floats_cons.append(
-                    nnsmith_le(ph.out_shape.nelement(), self.limit_float // 16)
+                    nnsmith_le(ph.ttype.nelement(), self.limit_float // 16)
                 )
         return ph
 
@@ -752,7 +752,7 @@ class PureSymbolGen(SimpleGenerator):
                 rank if rank != -1 else self.random_rank(), dtype=dtype
             )
             new_inp_placeholders.append(ph)
-            constraints.extend(ph.out_shape.gt_zero())
+            constraints.extend(ph.ttype.gt_zero())
 
         input_shapes = [p.out_shape for p in new_inp_placeholders]
         constraints.extend(node.checked_requires(input_shapes))

--- a/nnsmith/materialize/onnx/__init__.py
+++ b/nnsmith/materialize/onnx/__init__.py
@@ -87,6 +87,7 @@ def dtype_from_onnx(onnx_dtype: onnx.TensorProto.DataType) -> DType:
     return {
         onnx.TensorProto.DataType.FLOAT: DType.float32,
         onnx.TensorProto.DataType.DOUBLE: DType.float64,
+        onnx.TensorProto.DataType.UINT8: DType.uint8,
         onnx.TensorProto.DataType.INT8: DType.int8,
         onnx.TensorProto.DataType.INT16: DType.int16,
         onnx.TensorProto.DataType.INT32: DType.int32,

--- a/nnsmith/narrow_spec.py
+++ b/nnsmith/narrow_spec.py
@@ -79,8 +79,8 @@ def _make_single_op_schedules(
 
         this_op = deepcopy(op)
         outputs = this_op.checked_type_transfer(inputs)
-        this_op.input_like = inputs
-        this_op.output_like = outputs
+        this_op.bind_input_like(inputs)
+        this_op.bind_output_like(outputs)
 
         leaf_keys = list(range(len(inputs), len(inputs) + len(outputs)))
 

--- a/requirements/sys/tvm.txt
+++ b/requirements/sys/tvm.txt
@@ -1,2 +1,3 @@
---pre
-apache-tvm # need to play with tag `--pre`
+# TODO(@ganler): switch back to pre-release after the merge
+# and release of https://github.com/apache/tvm/pull/13448
+apache-tvm==0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,15 +22,20 @@ install_requires =
 
 # TODO: make it nightly.
 [options.extras_require]
-onnx = onnx
+onnx = torch
+       onnx
 ort = onnxruntime
+      torch
+      onnx
 tf = tf-nightly
 torch = torch
 tvm = apache-tvm
-iree = iree-compiler
+      torch
+      onnx
+iree = tf-nightly
+       iree-compiler
        iree-runtime
        iree-tools-tf
-       importlib_metadata
 
 [options.package_data]
 nnsmith = config/**/*.yaml

--- a/tests/core/test_gir.py
+++ b/tests/core/test_gir.py
@@ -1,0 +1,206 @@
+import pytest
+
+from nnsmith.abstract.dtype import DType
+from nnsmith.abstract.op import *
+from nnsmith.gir import *
+
+
+@mark_abstract("test")
+class FakeSwap(AbsOpBase):
+    in_dtypes = [(i, i) for i in DTYPE_ALL]
+    out_dtypes = [(i, i) for i in DTYPE_ALL]
+
+    def __init__(self):
+        super().__init__()
+        self.inp_ranks = [int_all(), int_all()]
+
+    def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
+        return [input_shapes[-1], input_shapes[0]]
+
+    def deduct_inp_ranks_and_dtype(
+        self, out_abs_tensor: List[AbsTensor]
+    ) -> List[Tuple[int, DType]]:
+        return [
+            (out_abs_tensor[1].ndims, out_abs_tensor[1].dtype),
+            (out_abs_tensor[0].ndims, out_abs_tensor[0].dtype),
+        ]
+
+
+def test_inst_expr():
+    ph = Placeholder(ttype=AbsTensor(shape=[2, 3, 3], dtype=DType.float32))
+    iexpr = InstExpr(ph, [])
+    assert iexpr.op == ph
+    assert iexpr.args == []
+    assert iexpr.n_input() == 0
+    assert iexpr.n_output() == 1
+
+    op = Add()
+    iexpr = InstExpr(op, ["a", "b"])
+    assert iexpr.op == op
+    assert iexpr.args == ["a", "b"]
+    assert iexpr.n_input() == 2
+    assert iexpr.n_output() == 1
+
+
+def test_inst_ir():
+    ph = Placeholder(ttype=AbsTensor(shape=[2, 3, 3], dtype=DType.float32))
+    iexpr = InstExpr(ph, [])
+    iir0 = InstIR(iexpr)
+    assert iir0.iexpr == iexpr
+    assert iir0.n_input() == 0
+    assert iir0.n_output() == 1
+    assert iir0.retval() == f"v{id(iir0)}.0"
+    assert list(iir0.retvals()) == [f"v{id(iir0)}.0"]
+    assert list(iir0.leaf_var()) == [f"v{id(iir0)}.0"]
+
+    op = FakeSwap()
+    iexpr = InstExpr(op, [iir0.retval(), iir0.retval()])
+    iir1 = InstIR(iexpr, irctx=[iir0])
+    assert iir1.iexpr == iexpr
+    assert iir1.n_input() == 2
+    assert iir1.n_output() == 2
+    assert iir1.retval() == f"v{id(iir1)}.0"
+    assert iir1.retval(0) == f"v{id(iir1)}.0"
+    assert iir1.retval(1) == f"v{id(iir1)}.1"
+    assert list(iir1.retvals()) == [f"v{id(iir1)}.0", f"v{id(iir1)}.1"]
+
+    inst_id, index = InstIR.var_inst_idx(iir1.retval(1))
+    assert inst_id == id(iir1)
+    assert index == 1
+
+    # Check udchain
+    assert iir1.is_user_of(iir0)  # This check actually does not rely on obj id.
+    assert iir1 in iir0.users[0]
+    assert iir1.no_users()
+    assert not iir0.is_user_of(iir1, 0)
+    assert not iir0.is_user_of(iir1, 1)
+
+    # expect exception
+    with pytest.raises(ValueError):
+        iir1.is_user_of(iir0, 1)  # domain \in [0, 1)
+
+
+def test_gir_mutate():
+    ir = GraphIR()
+
+    ph1 = ir.add_inst(
+        InstExpr(Placeholder(ttype=AbsTensor(shape=[2, 3, 3], dtype=DType.float32)), [])
+    )
+    # Insert
+    swap1 = ir.add_inst(InstExpr(FakeSwap(), [ph1.retval(), ph1.retval()]))
+
+    assert ir.n_var() == 3
+    assert ir.n_compute_inst() == 1
+    assert len(ir.leaf_inst()) == 1
+    assert ir.leaf_var() == [f"v{id(swap1)}.0", f"v{id(swap1)}.1"]
+
+    assert (
+        ir.pretty()
+        == """v0.0 = Placeholder() \t# inst id: 0
+v1.0, v1.1 = test.FakeSwap(v0.0, v0.0) \t# inst id: 1
+"""
+    )
+
+    ir.assert_wellform()
+
+    # IR: (ph1, ph1)=>(swap)
+    # Backward insert a placeholder
+    ph2 = ir.add_inst(
+        InstExpr(Placeholder(ttype=AbsTensor(shape=[2, 3, 3], dtype=DType.float32)), [])
+    )
+    # IR: (ph2, ph1)=>(swap)
+    ir.replace_arg(swap1, 0, ph2.retval())
+
+    assert ir.n_var() == 4
+    assert ir.n_compute_inst() == 1
+    assert len(ir.leaf_inst()) == 1
+    assert ir.leaf_var() == [f"v{id(swap1)}.0", f"v{id(swap1)}.1"]
+    ir.assert_wellform()
+
+    assert (
+        ir.pretty()
+        == """v0.0 = Placeholder() \t# inst id: 0
+v1.0 = Placeholder() \t# inst id: 1
+v2.0, v2.1 = test.FakeSwap(v0.0, v1.0) \t# inst id: 2
+"""
+    )
+
+    # IR: (ph2, ph1)=>(swap1)=>(swap2)
+    #                       \=>swap.1
+    swap2 = ir.add_inst(InstExpr(FakeSwap(), [swap1.retval(0), swap1.retval(0)]))
+    assert ir.n_var() == 6
+    assert ir.n_compute_inst() == 2
+    assert len(ir.leaf_inst()) == 1
+    assert ir.leaf_var() == [f"v{id(swap1)}.1", f"v{id(swap2)}.0", f"v{id(swap2)}.1"]
+    ir.assert_wellform()
+
+    assert (
+        ir.pretty()
+        == """v0.0 = Placeholder() \t# inst id: 0
+v1.0 = Placeholder() \t# inst id: 1
+v2.0, v2.1 = test.FakeSwap(v0.0, v1.0) \t# inst id: 2
+v3.0, v3.1 = test.FakeSwap(v2.0, v2.0) \t# inst id: 3
+"""
+    )
+
+    # replace swap1 with add
+    # IR: (ph2, ph1)=>(add)=>(swap2)
+    add = ir.add_inst(InstExpr(Add(), [ph2.retval(), ph1.retval()]))
+    ir.replace_alluse(swap1.retval(0), add.retval())
+    ir.remove_unused(swap1)
+
+    assert ir.n_var() == 5
+    assert ir.n_compute_inst() == 2
+    assert len(ir.leaf_inst()) == 1
+    assert ir.leaf_var() == [f"v{id(swap2)}.0", f"v{id(swap2)}.1"]
+    ir.assert_wellform()
+
+    assert (
+        ir.pretty()
+        == """v0.0 = Placeholder() \t# inst id: 0
+v1.0 = Placeholder() \t# inst id: 1
+v2.0 = core.Add(v0.0, v1.0) \t# inst id: 2
+v3.0, v3.1 = test.FakeSwap(v2.0, v2.0) \t# inst id: 3
+"""
+    )
+
+
+def test_gir_repair():
+    # Given a graph of wrong topological order or use-def chain, we can repair it.
+    ir = GraphIR()
+    ph = ir.add_inst(
+        InstExpr(Placeholder(ttype=AbsTensor(shape=[2, 3, 3], dtype=DType.float32)), [])
+    )
+    swap = ir.add_inst(InstExpr(FakeSwap(), [ph.retval(), ph.retval()]))
+
+    ir.assert_wellform()
+    assert ph.users[0] == {swap}
+
+    # 1.1 Repair missed use.
+    ph.users[0] = set()  # violate the user
+    with pytest.raises(AssertionError):
+        ir.assert_wellform()
+
+    ir._udchain_repair()
+    ir.assert_wellform()
+    assert ph.users[0] == {swap}
+
+    # 1.2 Repair invalid use.
+    swap.users[1] = {swap}  # create non-existing use
+    with pytest.raises(AssertionError):
+        ir.assert_wellform()
+
+    ir._udchain_repair()
+    ir.assert_wellform()
+    assert not swap.users[0]
+    assert not swap.users[1]
+
+    # 2. Repair bad topological order.
+    ir.insts[0], ir.insts[1] = ir.insts[1], ir.insts[0]
+    with pytest.raises(AssertionError):
+        ir.assert_wellform()
+
+    ir._topological_sort()
+    ir.assert_wellform()
+    assert ir.insts[0] == ph
+    assert ir.insts[1] == swap


### PR DESCRIPTION
- Sharpened GraphIR to support various mutations and multiple return values. 
   - SSA (ack LLVM IR and ONNX)
   - Allow multiple return values (ack ONNX) but bound to instructions. (return value identifier is ${instruction_id}.{index}).
   - Mutation: IR-safety oriented mutation APIs: 1) replace use; 2) remove unused; 3) insert; so that given a valid GraphIR each operation should return an also valid GraphIR;
   - IR Repair: allow partial validity: the topology order and use-def chain of a GraphIR can be broken but later fixed by `GraphIR.wellform_repair`. This is designed for some longer-context IR mutation;
   - Integration of GraphIR to all existing pipelines is still under development in experimental repo/branches and will be upstreamed once found steady.
- Other minor improvements: add a few data type supports (still not used in generation tho) to allow NNReduce to debug quantized models.