### PR TITLE
Unify Graph Generation Infra with GraphIR Integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened]
+  push:
+    branches: [main]
 
 jobs:
   pytest:

--- a/nnsmith/abstract/dtype.py
+++ b/nnsmith/abstract/dtype.py
@@ -3,7 +3,6 @@ from enum import Enum, unique
 import numpy as np
 
 
-# TODO(@ganler): add float16 support.
 @unique
 class DType(Enum):
     float16 = "float16"

--- a/nnsmith/abstract/dtype.py
+++ b/nnsmith/abstract/dtype.py
@@ -153,6 +153,21 @@ class DType(Enum):
             tf.bool: DType.bool,
         }[dtype]
 
+    def sizeof(self) -> int:
+        return {
+            DType.float16: 2,
+            DType.float32: 4,
+            DType.float64: 8,
+            DType.uint8: 1,
+            DType.int8: 1,
+            DType.int16: 2,
+            DType.int32: 4,
+            DType.int64: 8,
+            DType.complex64: 8,
+            DType.complex128: 16,
+            DType.bool: 1,  # Follow C/C++ convention.
+        }[self]
+
 
 DTYPE_ALL = [
     DType.float32,

--- a/nnsmith/abstract/op.py
+++ b/nnsmith/abstract/op.py
@@ -655,6 +655,14 @@ class Input(AbsOpBase):
     ) -> List[Tuple[int, DType]]:
         pass
 
+    @property
+    def input_like(self):
+        return []
+
+    @property
+    def output_like(self):
+        return [self.abs_tensor]
+
 
 class Constant(AbsOpBase):
     in_dtypes = [()]
@@ -685,6 +693,14 @@ class Constant(AbsOpBase):
         self, out_abs_tensor: List[AbsTensor]
     ) -> List[Tuple[int, DType]]:
         pass
+
+    @property
+    def input_like(self):
+        return []
+
+    @property
+    def output_like(self):
+        return [self.abs_tensor]
 
 
 class Placeholder:

--- a/nnsmith/abstract/op.py
+++ b/nnsmith/abstract/op.py
@@ -79,19 +79,19 @@ class mark_materialize:
         return op_type
 
 
-def int_from(start):
+def rank_from(start):
     return tuple(range(start, __MAX_RANK__ + 1))
 
 
-def int_range(start, end):
+def rank_range(start, end):
     return tuple(range(start, end + 1))
 
 
-def int_until(end):
+def rank_until(end):
     return tuple(range(__MIN_RANK__, end + 1))
 
 
-def int_all():
+def rank_all():
     return tuple(range(__MIN_RANK__, __MAX_RANK__ + 1))
 
 
@@ -417,7 +417,7 @@ class UnaryOpBase(AbsOpBase):
 
     def __init__(self):
         super().__init__()
-        self.out_ranks = [int_all()]
+        self.out_ranks = [rank_all()]
 
 
 class BinaryOpBase(AbsOpBase):
@@ -426,7 +426,7 @@ class BinaryOpBase(AbsOpBase):
 
     def __init__(self):
         super().__init__()
-        self.out_ranks = [int_all()]
+        self.out_ranks = [rank_all()]
 
 
 class TernaryOpBase(AbsOpBase):
@@ -435,14 +435,14 @@ class TernaryOpBase(AbsOpBase):
 
     def __init__(self):
         super().__init__()
-        self.out_ranks = [int_all()]
+        self.out_ranks = [rank_all()]
 
 
 class ElementWiseUnaryOp(UnaryOpBase):
     def __init__(self):
         super().__init__()
-        self.inp_ranks = [int_all()]
-        self.out_ranks = [int_all()]
+        self.inp_ranks = [rank_all()]
+        self.out_ranks = [rank_all()]
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
         SanityCheck.eq(len(input_shapes), 1)
@@ -468,7 +468,7 @@ class BcastBinaryOp(BinaryOpBase):
 
     def __init__(self):
         super().__init__()
-        self.inp_ranks = [int_all(), int_all()]
+        self.inp_ranks = [rank_all(), rank_all()]
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
         tgt_shape = broadcast_shapes(*(ish.shape for ish in input_shapes))
@@ -529,7 +529,7 @@ class Where(TernaryOpBase):
 
     def __init__(self):
         super().__init__()
-        self.inp_ranks = [int_all(), int_all(), int_all()]
+        self.inp_ranks = [rank_all(), rank_all(), rank_all()]
         self.same_inp_dtypes = True
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
@@ -862,8 +862,8 @@ class Softmax(ElementWiseUnaryOp):
     def __init__(self, dim: Union[int, z3.ExprRef]):
         super().__init__()
         self.dim = dim
-        self.inp_ranks = [int_from(1)]
-        self.out_ranks = [int_from(1)]
+        self.inp_ranks = [rank_from(1)]
+        self.out_ranks = [rank_from(1)]
 
     def requires(self, input_shapes: List[AbsTensor]) -> List[Union[z3.BoolRef, bool]]:
         return [nnsmith_lt(self.dim, input_shapes[0].ndims), nnsmith_ge(self.dim, 0)]
@@ -989,8 +989,8 @@ class Slice(UnaryOpBase):
 
     def __init__(self, start, end, step):
         super().__init__()
-        self.inp_ranks = [int_from(1)]
-        self.out_ranks = [int_from(1)]
+        self.inp_ranks = [rank_from(1)]
+        self.out_ranks = [rank_from(1)]
         self.start = start
         self.end = end
         self.step = step
@@ -1103,8 +1103,8 @@ class Pad(UnaryOpBase):
         super().__init__()
         self.padding_list = padding_list
         self.extra_attrs["type"] = pad_t
-        self.inp_ranks = [int_from(len(padding_list) // 2)]
-        self.out_ranks = [int_from(len(padding_list) // 2)]
+        self.inp_ranks = [rank_from(len(padding_list) // 2)]
+        self.out_ranks = [rank_from(len(padding_list) // 2)]
         assert (
             len(self.padding_list) % 2 == 0
         ), f"padding_list must be even, got {self.padding_list}"
@@ -1152,8 +1152,8 @@ class ReplicatePad(Pad):
 
     def __init__(self, *padding_list):
         super().__init__(padding_list, "replicate")
-        self.inp_ranks = [int_range(len(padding_list) // 2 + 1, 4)]
-        self.out_ranks = [int_range(len(padding_list) // 2 + 1, 4)]
+        self.inp_ranks = [rank_range(len(padding_list) // 2 + 1, 4)]
+        self.out_ranks = [rank_range(len(padding_list) // 2 + 1, 4)]
 
 
 @mark_materialize("core")
@@ -1162,8 +1162,8 @@ class ReflectPad(Pad):
 
     def __init__(self, *padding_list):
         super().__init__(padding_list, "reflect")
-        self.inp_ranks = [int_range(len(padding_list) // 2 + 1, 4)]
-        self.out_ranks = [int_range(len(padding_list) // 2 + 1, 4)]
+        self.inp_ranks = [rank_range(len(padding_list) // 2 + 1, 4)]
+        self.out_ranks = [rank_range(len(padding_list) // 2 + 1, 4)]
 
     def requires(self, input_shapes: List[AbsTensor]) -> List[Union[z3.BoolRef, bool]]:
         cons = super().requires(input_shapes)
@@ -1187,7 +1187,7 @@ class Expand(UnaryOpBase, ABC):
     def __init__(self, expand_last_dim: int, expand_n: Union[int, z3.ExprRef]):
         """See https://pytorch.org/docs/stable/generated/torch.Tensor.expand.html"""
         super().__init__()
-        self.inp_ranks = [int_all()]
+        self.inp_ranks = [rank_all()]
         SanityCheck.ge(expand_last_dim, 1)
         self.expand_last_dim = expand_last_dim
         self.expand_n = expand_n
@@ -1544,13 +1544,13 @@ def random_group(n, k):
 
 @mark_materialize("core")
 class Reshape(UnaryOpBase):
-    num_var_param = int_range(1, 4)
+    num_var_param = rank_range(1, 4)
     in_dtypes = [(i,) for i in DTYPE_ALL]
     out_dtypes = [(i,) for i in DTYPE_ALL]
 
     def __init__(self, *target_shape):
         super().__init__()
-        self.inp_ranks = [int_range(1, 4)]
+        self.inp_ranks = [rank_range(1, 4)]
         self.out_ranks = [(len(target_shape),)]
         self.target_shape: List[Union[int, z3.ExprRef]] = list(target_shape)
 
@@ -1649,8 +1649,8 @@ class Transpose(UnaryOpBase):
     def __init__(self):
         """See https://pytorch.org/docs/stable/generated/torch.transpose.html"""
         super().__init__()
-        self.inp_ranks = [int_from(2)]
-        self.out_ranks = [int_from(2)]
+        self.inp_ranks = [rank_from(2)]
+        self.out_ranks = [rank_from(2)]
 
     def _init_swap_dims(self, input_shape: List[Union[int, z3.ExprRef]]):
         ConstraintCheck.ge(len(input_shape), 2)
@@ -1688,7 +1688,7 @@ class Transpose(UnaryOpBase):
 
 
 class InterpBase(UnaryOpBase):
-    num_var_param = int_range(1, 3)
+    num_var_param = rank_range(1, 3)
 
     in_dtypes = [(i,) for i in DTYPE_FLOATS]
     out_dtypes = [(i,) for i in DTYPE_FLOATS]
@@ -1744,8 +1744,8 @@ class ReduceBase(UnaryOpBase, ABC):
 
     def __init__(self):
         super().__init__()
-        self.inp_ranks = [int_from(1)]  # TVM bug ~ crash on scalar.min()
-        self.out_ranks = [int_range(0, __MAX_RANK__ - 1)]
+        self.inp_ranks = [rank_from(1)]  # TVM bug ~ crash on scalar.min()
+        self.out_ranks = [rank_range(0, __MAX_RANK__ - 1)]
 
     def __str__(self) -> str:
         return (
@@ -1909,8 +1909,8 @@ class Concat(AbsOpBase):
         super().__init__()
         SanityCheck.le(arity, Concat.MAX_ARITY)
         self.arity = arity
-        self.inp_ranks = [(int_from(1))] * arity
-        self.out_ranks = [(int_from(1))]
+        self.inp_ranks = [(rank_from(1))] * arity
+        self.out_ranks = [(rank_from(1))]
 
     def _init_concat_axis(self, input_shapes: List[AbsTensor]) -> int:
         if "axis" not in self.extra_attrs:
@@ -1993,8 +1993,8 @@ class Cast(ElementWiseUnaryOp, ABC):
 
     def __init__(self, dtype):
         super().__init__()
-        self.inp_ranks = [int_all()]
-        self.out_ranks = [int_all()]
+        self.inp_ranks = [rank_all()]
+        self.out_ranks = [rank_all()]
         self.extra_attrs = {"to": dtype}
 
     def __str__(self) -> str:
@@ -2061,8 +2061,8 @@ class MatMul(BinaryOpBase):
     def __init__(self):
         super().__init__()
         # Consider at most 3D tensors (batched mm)
-        self.inp_ranks = [int_range(1, 3), int_range(1, 3)]
-        self.out_ranks = [int_until(3)]
+        self.inp_ranks = [rank_range(1, 3), rank_range(1, 3)]
+        self.out_ranks = [rank_until(3)]
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
         # https://pytorch.org/docs/stable/generated/torch.matmul.html#torch.matmul

--- a/nnsmith/abstract/tensor.py
+++ b/nnsmith/abstract/tensor.py
@@ -81,10 +81,6 @@ class AbsTensor:
     def deepcopy(self):
         return AbsTensor(shape=list(self.shape), dtype=self.dtype)
 
-    @staticmethod
-    def from_torch(torch_tensor):
-        return AbsTensor(list(torch_tensor.shape), DType.from_torch(torch_tensor.dtype))
-
     @property
     def ndims(self):
         return len(self.shape)

--- a/nnsmith/abstract/tensor.py
+++ b/nnsmith/abstract/tensor.py
@@ -75,6 +75,9 @@ class AbsTensor:
             return 1
         return reduce(lambda x, y: nnsmith_mul(x, y), self.shape, 1)
 
+    def nbytes(self) -> int:
+        return self.nelement() * self.dtype.sizeof()
+
     def deepcopy(self):
         return AbsTensor(shape=list(self.shape), dtype=self.dtype)
 
@@ -85,3 +88,6 @@ class AbsTensor:
     @property
     def ndims(self):
         return len(self.shape)
+
+    def is_concrete(self) -> bool:
+        return all(isinstance(s, int) for s in self.shape)

--- a/nnsmith/backends/tflite.py
+++ b/nnsmith/backends/tflite.py
@@ -14,8 +14,7 @@ class TFLiteRunner:
         self.tfnet_callable = tfnet_callable
 
     def __call__(self, input: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
-        return self.tfnet_callable(**input)
-        # It can automatically convert input args to np.ndarray, and it outputs np.ndarray.
+        return {k: np.array(v) for k, v in self.tfnet_callable(**input).items()}
 
 
 class TFLiteFactory(BackendFactory):

--- a/nnsmith/config/main.yaml
+++ b/nnsmith/config/main.yaml
@@ -26,7 +26,6 @@ model:
   path: "???" # can be multiple files tho.
 
 mgen: # model gen.
-  init_rank: 4
   max_nodes: 5
   timeout_ms: 50000
   vulops: False

--- a/nnsmith/difftest.py
+++ b/nnsmith/difftest.py
@@ -22,13 +22,18 @@ def assert_allclose(
         lhs = actual[key]
         rhs = desired[key]
 
-        # check if lhs is np.ndarray
-        if not isinstance(lhs, np.ndarray):
-            raise TypeError(f"{actual_name}[{key}] is not np.ndarray but {type(lhs)}")
+        # check lhs & rhs same type and not None
+        # 1. same type
+        if type(lhs) is not type(rhs):
+            raise TypeError(
+                f"type({actual_name}[{key}]): {type(lhs)} != type({oracle_name}[{key}]): {type(rhs)}"
+            )
 
-        # check if rhs is np.ndarray
-        if not isinstance(rhs, np.ndarray):
-            raise TypeError(f"{oracle_name}[{key}] is not np.ndarray but {type(rhs)}")
+        # 2. not None
+        if lhs is None:
+            raise TypeError(f"{actual_name}[{key}] is None")
+        if rhs is None:
+            raise TypeError(f"{oracle_name}[{key}] is None")
 
         testing.assert_allclose(
             lhs,

--- a/nnsmith/difftest.py
+++ b/nnsmith/difftest.py
@@ -22,18 +22,13 @@ def assert_allclose(
         lhs = actual[key]
         rhs = desired[key]
 
-        # check lhs & rhs same type and not None
-        # 1. same type
-        if type(lhs) is not type(rhs):
-            raise TypeError(
-                f"type({actual_name}[{key}]): {type(lhs)} != type({oracle_name}[{key}]): {type(rhs)}"
-            )
+        # check if lhs is np.ndarray
+        if not isinstance(lhs, np.ndarray):
+            raise TypeError(f"{actual_name}[{key}] is not np.ndarray but {type(lhs)}")
 
-        # 2. not None
-        if lhs is None:
-            raise TypeError(f"{actual_name}[{key}] is None")
-        if rhs is None:
-            raise TypeError(f"{oracle_name}[{key}] is None")
+        # check if rhs is np.ndarray
+        if not isinstance(rhs, np.ndarray):
+            raise TypeError(f"{oracle_name}[{key}] is not np.ndarray but {type(rhs)}")
 
         testing.assert_allclose(
             lhs,

--- a/nnsmith/gir.py
+++ b/nnsmith/gir.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from z3 import ModelRef
 
@@ -54,10 +54,12 @@ class InstIR:
     def no_users(self):
         return all(len(u) == 0 for u in self.users)
 
-    def leaf_var(self) -> Iterable[str]:
+    def leaf_var(self) -> List[str]:
+        ret = []
         for idx, users in enumerate(self.users):
             if len(users) == 0:
-                yield self.retval(idx)
+                ret.append(self.retval(idx))
+        return ret
 
     def n_input(self):
         return self.iexpr.n_input()
@@ -75,9 +77,8 @@ class InstIR:
         assert index < self.n_output(), f"Only has {self.n_output()} outputs in {self}"
         return f"v{id(self)}.{index}"
 
-    def retvals(self) -> Iterable[str]:
-        for i in range(self.n_output()):
-            yield self.retval(i)
+    def retvals(self) -> List[str]:
+        return [self.retval(i) for i in range(self.n_output())]
 
     def is_user_of(self, inst: "InstIR", ret_idx: Optional[int] = None) -> bool:
         usee_names = list(inst.retvals())
@@ -151,7 +152,9 @@ class GraphIR:
         return lvs
 
     def input_var(self) -> List[str]:
-        return [inst.retval() for inst in self.insts if inst.iexpr.op == Input]
+        return [
+            inst.retval() for inst in self.insts if isinstance(inst.iexpr.op, Input)
+        ]
 
     def add_inst(self, iexpr: InstExpr) -> InstIR:
         new_inst = InstIR(iexpr)

--- a/nnsmith/graph_gen.py
+++ b/nnsmith/graph_gen.py
@@ -365,8 +365,7 @@ class SimpleGenerator:
         ]
         if len(dtype_combs) == 0:
             raise RequiredDimNotFound(
-                "Op %s: Cannot find a shape variable with dim_spec %s and dtype combinations %s."
-                % (ndim_list, dtype_combs_spec)
+                f"No viable candidates: rank within {ndim_list} and dtype within {dtype_combs_spec}."
             )
         dtype_comb = random.choice(dtype_combs)
         for i, ndims in enumerate(ndim_list):

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -2,17 +2,14 @@ import json
 import os
 import pickle
 from abc import ABC, abstractmethod
-from collections import namedtuple
-from dataclasses import dataclass
 from enum import Enum
 from os import PathLike
-from typing import Any, Dict, List, Tuple, Type, TypeVar
+from typing import Any, Dict, List, Type, TypeVar
 
-import networkx as nx
 import numpy as np
 from multipledispatch import dispatch
 
-from nnsmith.abstract.op import AbsOpBase, Constant, Input
+from nnsmith.abstract.op import AbsOpBase, Constant
 from nnsmith.abstract.tensor import AbsTensor
 from nnsmith.error import SanityCheck
 from nnsmith.gir import GraphIR

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -55,11 +55,6 @@ def framework_operator_impl(
     return dispatch(op_type, *args, **kwargs)
 
 
-Instruction: Tuple[AbsOpBase, List[int], List[int]] = namedtuple(
-    "Instruction", ["op", "inputs", "outputs"]
-)
-
-
 class Oracle:
     def __init__(
         self,

--- a/nnsmith/materialize/tensorflow/__init__.py
+++ b/nnsmith/materialize/tensorflow/__init__.py
@@ -28,7 +28,8 @@ def configure_tf_gpu_mem(max_megabytes=None):
 configure_tf_gpu_mem()
 
 from nnsmith.abstract.op import AbsOpBase, AbsTensor
-from nnsmith.materialize import Model, Oracle, Schedule
+from nnsmith.gir import GraphIR
+from nnsmith.materialize import Model, Oracle
 from nnsmith.materialize.tensorflow.forward import ALL_TF_OPS
 from nnsmith.materialize.tensorflow.tfnet import TFNet
 from nnsmith.util import register_seed_setter
@@ -73,17 +74,14 @@ class TFModel(Model, ABC):  # Don't directly instantiate this class
     Other values like I/O values should be managed by the user.
     """
 
-    def __init__(self, schedule: Schedule) -> None:
-        """Must provide a schedule to avoid NoneType errors"""
+    def __init__(self, ir: GraphIR) -> None:
         super().__init__()
-        self.schedule = schedule
-        self.net: TFNet = TFNet(
-            schedule=schedule,
-        )
+        self.ir = ir
+        self.net = TFNet(ir=ir)
 
     @classmethod
-    def from_schedule(cls, schedule: Schedule, **kwargs) -> "TFModel":
-        return cls(schedule)
+    def from_gir(cls: Type["TFModel"], ir: GraphIR, **kwargs) -> "TFModel":
+        return cls(ir)
 
     @property
     def version(self) -> str:
@@ -96,22 +94,22 @@ class TFModel(Model, ABC):  # Don't directly instantiate this class
     @property
     def input_like(self) -> Dict[str, AbsTensor]:
         return {
-            f"i{i_inp}": self.schedule.key2type[key]
-            for i_inp, key in enumerate(self.schedule.input_keys)
+            f"i{i_inp}": self.gir.key2type[key]
+            for i_inp, key in enumerate(self.gir.input_keys)
         }
 
     @property
     def output_like(self) -> Dict[str, AbsTensor]:
         return {
-            f"o{i_out}": self.schedule.key2type[key]
-            for i_out, key in enumerate(self.schedule.leaf_keys)
+            f"o{i_out}": self.gir.key2type[key]
+            for i_out, key in enumerate(self.gir.leaf_keys)
         }
 
     @property
     def input_specs(self) -> Dict[str, tf.TensorSpec]:
         ret: Dict[str, tf.TensorSpec] = {}
-        for i_inp, key in enumerate(self.schedule.input_keys):
-            abs_tensor = self.schedule.key2type[key]
+        for i_inp, key in enumerate(self.gir.input_keys):
+            abs_tensor = self.gir.key2type[key]
             ret[f"i{i_inp}"] = tf.TensorSpec(
                 abs_tensor.shape, abs_tensor.dtype.tensorflow(), f"i{i_inp}"
             )
@@ -137,9 +135,9 @@ class TFModel(Model, ABC):  # Don't directly instantiate this class
 
     def dump(self, path: PathLike = "saved_tfmodel") -> None:
         os.makedirs(path, exist_ok=True)
-        # schedule.pkl
-        with open(os.path.join(path, TFModel.schedule_name()), "wb") as f:
-            pickle.dump(self.schedule, f)
+        # gir.pkl
+        with open(os.path.join(path, TFModel.gir_name()), "wb") as f:
+            pickle.dump(self.gir, f)
         # tfnet
         with self.device:
             concrete_net = self.concrete_net(self.input_specs)
@@ -160,15 +158,15 @@ class TFModel(Model, ABC):  # Don't directly instantiate this class
 
     @classmethod
     def load(cls, path: PathLike) -> "TFModel":
-        with open(os.path.join(path, cls.schedule_name()), "rb") as f:
-            schedule: Schedule = pickle.load(f)
-        model = cls(schedule)
+        with open(os.path.join(path, cls.gir_name()), "rb") as f:
+            gir: GraphIR = pickle.load(f)
+        model = cls(gir)
         model.net = tf.saved_model.load(os.path.join(path, TFModel.tfnet_dir_name()))
         return model
 
     @staticmethod
-    def schedule_name():
-        return "schedule.pkl"
+    def gir_name() -> str:
+        return "gir.pkl"
 
     @staticmethod
     def in_out_pkl_name():

--- a/nnsmith/materialize/tensorflow/__init__.py
+++ b/nnsmith/materialize/tensorflow/__init__.py
@@ -46,7 +46,7 @@ def randn_from_specs(specs: Dict[str, tf.TensorSpec]) -> Dict[str, tf.Tensor]:
 
 
 def np_dict_from_tf(x: Dict[str, tf.Tensor]) -> Dict[str, np.ndarray]:
-    return {key: value.numpy() for key, value in x.items()}
+    return {key: np.array(value.numpy()) for key, value in x.items()}
 
 
 def tf_dict_from_np(x: Dict[str, np.ndarray]) -> Dict[str, tf.Tensor]:

--- a/nnsmith/materialize/tensorflow/dialect.py
+++ b/nnsmith/materialize/tensorflow/dialect.py
@@ -9,8 +9,8 @@ from nnsmith.abstract.op import (
     BcastBinaryOp,
     ElementWiseUnaryOp,
     UnaryOpBase,
-    int_from,
     mark_materialize,
+    rank_from,
 )
 from nnsmith.abstract.tensor import AbsTensor
 from nnsmith.error import ConstraintCheck
@@ -26,10 +26,10 @@ class Dense(UnaryOpBase):
         self.ifeat = ifeat
         self.ofeat = ofeat
         self.inp_ranks = [
-            int_from(2)
+            rank_from(2)
         ]  # NOTE: tensorflow Dense layer requires an input with batch as its first axis
         # at least one dim. cannot be zranks_all()
-        self.out_ranks = [int_from(2)]
+        self.out_ranks = [rank_from(2)]
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
         assert len(input_shapes) == 1, "Linear only takes one input, but got {}".format(

--- a/nnsmith/materialize/tensorflow/tfnet.py
+++ b/nnsmith/materialize/tensorflow/tfnet.py
@@ -13,8 +13,8 @@ from nnsmith.materialize.tensorflow.forward import forward_fn
 @dataclass
 class Instr:
     fwd_fn: Callable
-    inp_keys: List[int]
-    out_keys: List[int]
+    inp_keys: List[str]
+    out_keys: List[str]
 
 
 class TFNet(tf.Module):
@@ -31,14 +31,14 @@ class TFNet(tf.Module):
         self.mlist: List[Callable] = []
         self.instructions: List[Instr] = []
 
-        for op, inp_keys, out_keys in self.ir.instructions:
-            if not isinstance(op, Input):
-                op = cast(AbsOpBase, op)
+        for inst in self.ir.insts:
+            if not isinstance(inst.iexpr.op, Input):
+                op = cast(AbsOpBase, inst.iexpr.op)
                 fwd_fn = forward_fn(op)
-                SanityCheck.true(fwd_fn is not None, f"Bad implementation for {op}")
-                if not isinstance(op, tf.Module):
+                SanityCheck.true(fwd_fn is not None, f"Bad impl for {inst.iexpr.op}")
+                if isinstance(fwd_fn, tf.Module):
                     self.mlist.append(fwd_fn)  # Add tf.Module to track its parameters
-                self.instructions.append(Instr(fwd_fn, inp_keys, out_keys))
+                self.instructions.append(Instr(fwd_fn, inst.iexpr.args, inst.retvals()))
 
     @tf.function
     def __call__(self, *args, **kwargs) -> Dict[str, tf.Tensor]:
@@ -53,13 +53,13 @@ class TFNet(tf.Module):
         mode = "Running Eagerly" if tf.executing_eagerly() else "Tracing"
         TF_LOG.debug(f"{mode} with JIT config: {tf.config.optimizer.get_jit()}")
 
-        key2tensor: Dict[int, tf.Tensor] = {}
+        key2tensor: Dict[str, tf.Tensor] = {}
         if len(args) == len(self.ir.input_var()):
             for i, key in enumerate(self.ir.input_var()):
                 key2tensor[key] = args[i]
         elif len(kwargs) == len(self.ir.input_var()):
             for i, key in enumerate(self.ir.input_var()):
-                key2tensor[key] = kwargs[f"i{i}"]
+                key2tensor[key] = kwargs[key]
         else:
             raise ValueError("Either user args only or kwargs only")
 
@@ -78,6 +78,4 @@ class TFNet(tf.Module):
             for i_out, out_key in enumerate(instr.out_keys):
                 key2tensor[out_key] = out_tensors[i_out]
 
-        # end for instructions
-        out_dict = {f"o{i}": key2tensor[key] for i, key in enumerate(self.ir.leaf_keys)}
-        return out_dict
+        return {k: key2tensor[k] for k in self.ir.leaf_var()}

--- a/nnsmith/materialize/tensorflow/tfnet.py
+++ b/nnsmith/materialize/tensorflow/tfnet.py
@@ -20,7 +20,7 @@ class Instr:
 class TFNet(tf.Module):
     """A TensorFlow network whose computation is defined by a GraphIR."""
 
-    def __init__(self, ir: GraphIR) -> None:  # TODO(@ganler): impl
+    def __init__(self, ir: GraphIR) -> None:
         """Build a TensorFlow model from GraphIR
 
         Args:

--- a/nnsmith/materialize/torch/dialect.py
+++ b/nnsmith/materialize/torch/dialect.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Union
 
 from nnsmith.abstract.arith import *
 from nnsmith.abstract.dtype import DTYPE_ALL, DTYPE_NON_BOOLS, DType
-from nnsmith.abstract.op import ReduceBase, UnaryOpBase, int_from, mark_materialize
+from nnsmith.abstract.op import ReduceBase, UnaryOpBase, mark_materialize, rank_from
 from nnsmith.abstract.tensor import AbsTensor
 from nnsmith.error import ConstraintCheck
 
@@ -18,8 +18,8 @@ class Linear(UnaryOpBase):
         super().__init__()
         self.ifeat = ifeat
         self.ofeat = ofeat
-        self.inp_ranks = [int_from(1)]
-        self.out_ranks = [int_from(1)]
+        self.inp_ranks = [rank_from(1)]
+        self.out_ranks = [rank_from(1)]
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
         assert len(input_shapes) == 1, "Linear only takes one input, but got {}".format(
@@ -52,7 +52,7 @@ class Flatten(UnaryOpBase):
 
     def __init__(self):
         super().__init__()
-        self.inp_ranks = [int_from(1)]
+        self.inp_ranks = [rank_from(1)]
         self.out_ranks = [(1,)]
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:

--- a/nnsmith/materialize/torch/forward.py
+++ b/nnsmith/materialize/torch/forward.py
@@ -269,9 +269,13 @@ def forward_fn(op: Pad):
         )
 
 
+def type_from_torch_tensor(tensor: torch.Tensor):
+    return AbsTensor(list(tensor.shape), DType.from_torch(tensor.dtype))
+
+
 @operator_impl(Expand)
 def forward_fn(op: Expand):
-    return lambda x: x.expand(*op.type_transfer([AbsTensor.from_torch(x)])[0].shape)
+    return lambda x: x.expand(*op.type_transfer([type_from_torch_tensor(x)])[0].shape)
 
 
 @operator_impl(BatchNorm2d)

--- a/nnsmith/materialize/torch/symbolnet.py
+++ b/nnsmith/materialize/torch/symbolnet.py
@@ -289,7 +289,6 @@ class SymbolNet(nn.Module):
 
     @torch.jit.ignore
     def debug_numeric(self, tensor_map):
-        # TODO(@ganler): optimize warning at export.
         with warnings.catch_warnings():  # just shutup.
             warnings.simplefilter("ignore")
             ConstraintCheck.true(

--- a/nnsmith/materialize/torch/symbolnet.py
+++ b/nnsmith/materialize/torch/symbolnet.py
@@ -95,14 +95,8 @@ class SymbolNet(nn.Module):
 
         # the order follows `input_keys`
 
-        self.input_map = {
-            f"i{i}": self.ir.vars[k] for i, k in enumerate(self.ir.input_var())
-        }
-        self.output_map = {
-            f"o{i}": self.ir.vars[k] for i, k in enumerate(self.ir.leaf_var())
-        }
-        self.iname2key = {f"i{i}": k for i, k in enumerate(self.ir.input_var())}
-        self.oname2key = {f"o{i}": k for i, k in enumerate(self.ir.leaf_var())}
+        self.input_map = {iname: self.ir.vars[iname] for iname in self.ir.input_var()}
+        self.output_map = {oname: self.ir.vars[oname] for oname in self.ir.leaf_var()}
 
         self.first_run = True
 
@@ -311,14 +305,14 @@ class SymbolNet(nn.Module):
     def forward(self, *args, **kwargs):
         self.differentiable = True
 
-        tensor_map = {}
+        tensor_map: Dict[str, torch.Tensor] = {}
 
         if len(args) == len(self.input_map):
             for i, key in enumerate(self.ir.input_var()):
                 tensor_map[key] = args[i]
         elif len(kwargs) == len(self.input_map):
-            for readable in self.input_map:
-                tensor_map[self.iname2key[readable]] = kwargs[readable]
+            for ir_key in self.input_map:
+                tensor_map[ir_key] = kwargs[ir_key]
         else:
             raise ValueError("Either user args only or kwargs only")
 
@@ -427,4 +421,4 @@ class SymbolNet(nn.Module):
                     return output_tensors
 
         self.first_run = False
-        return tuple(tensor_map[key] for key in self.oname2key.values())
+        return tuple(tensor_map[key] for key in self.output_map)

--- a/nnsmith/narrow_spec.py
+++ b/nnsmith/narrow_spec.py
@@ -34,7 +34,7 @@ from nnsmith.abstract.extension import BACKEND_REQUIRES
 from nnsmith.abstract.op import AbsOpBase, AbsTensor, Constant, Input, concretize_op
 from nnsmith.backends import BackendFactory
 from nnsmith.logging import DTEST_LOG
-from nnsmith.materialize import Instruction, Model, Schedule, TestCase
+from nnsmith.materialize import Instruction, Model, TestCase
 
 NNSMITH_CACHE_DIR = user_cache_dir(f"nnsmith-{__version__}")
 
@@ -53,6 +53,7 @@ class OpConfig:
     out_dtypes: List[List[DType]]
 
 
+# TODO(@ganler): impl
 def _make_single_op_schedules(
     op: AbsOpBase, ishapes, available_idtypes
 ):  # List<Tup<DTypeComb,DTypeComb,Sched>>

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,4 @@
 z3-solver>=4.11.0
-networkx>=2.6.3
 hydra-core>=1.1.0
 hydra_colorlog
 multipledispatch

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ python_requires = >=3.6
 dependency_links =
 install_requires =
     z3-solver>=4.11.0
-    networkx>=2.6.3
     hydra-core>=1.1.0
     hydra_colorlog
     multipledispatch

--- a/tests/core/test_gir.py
+++ b/tests/core/test_gir.py
@@ -12,7 +12,7 @@ class FakeSwap(AbsOpBase):
 
     def __init__(self):
         super().__init__()
-        self.inp_ranks = [int_all(), int_all()]
+        self.inp_ranks = [rank_all(), rank_all()]
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
         return [input_shapes[-1], input_shapes[0]]

--- a/tests/core/test_gir.py
+++ b/tests/core/test_gir.py
@@ -209,3 +209,31 @@ def test_gir_repair():
     ir.assert_wellform()
     assert ir.insts[0] == ph
     assert ir.insts[1] == swap
+
+
+def test_gir_dot():
+    ir = GraphIR()
+
+    ph1 = ir.add_inst(
+        InstExpr(Placeholder(ttype=AbsTensor(shape=[2, 3, 3], dtype=DType.float32)), [])
+    )
+    ir.add_inst(InstExpr(FakeSwap(), [ph1.retval(), ph1.retval()]))
+
+    assert (
+        ir.pretty()
+        == """v0.0 = Placeholder() \t# inst id: 0
+v1.0, v1.1 = test.FakeSwap(v0.0, v0.0) \t# inst id: 1
+"""
+    )
+
+    assert (
+        ir.to_dot()
+        == r"""digraph D {
+  node [shape=Mrecord];
+  0 [label="{Placeholder|{<o0> v0.0}}",fillcolor=lightgray,style=filled,];
+  1 [label="{{<i0> v0.0|<i1> v0.0}|test.FakeSwap|{<o0> v1.0|<o1> v1.1}}",];
+  0:o0 -> 1:i0;
+  0:o0 -> 1:i1;
+}
+"""
+    )

--- a/tests/tensorflow/test_iree_backend.py
+++ b/tests/tensorflow/test_iree_backend.py
@@ -2,8 +2,8 @@ import pytest
 
 from nnsmith.abstract.dtype import DType
 from nnsmith.backends import BackendFactory
-from nnsmith.graph_gen import concretize_graph, random_model_gen
-from nnsmith.materialize import Model, Schedule, TestCase
+from nnsmith.graph_gen import random_model_gen
+from nnsmith.materialize import Model, TestCase
 from nnsmith.narrow_spec import auto_opconfig, auto_opset
 
 TestCase.__test__ = False  # supress PyTest warning
@@ -40,18 +40,12 @@ def test_synthesized_tf_model(tmp_path):
 
         gen = random_model_gen(
             opset=auto_opset(ModelType, factory),
-            init_rank=4,
             seed=23132,
             max_nodes=4,
         )  # One op should not be easily wrong... I guess.
 
-        fixed_graph, concrete_abstensors = concretize_graph(
-            gen.abstract_graph, gen.tensor_dataflow, gen.get_solutions()
-        )
-
-        schedule = Schedule.init(fixed_graph, concrete_abstensors)
-
-        model = ModelType.from_schedule(schedule)
+        gen.ir.concretize(gen.get_sat_model())
+        model = ModelType.from_gir(gen.ir)
 
         oracle = model.make_oracle()
 

--- a/tests/tensorflow/test_tflite_backend.py
+++ b/tests/tensorflow/test_tflite_backend.py
@@ -2,8 +2,8 @@ import pytest
 
 from nnsmith.abstract.dtype import DType
 from nnsmith.backends import BackendFactory
-from nnsmith.graph_gen import concretize_graph, random_model_gen
-from nnsmith.materialize import Model, Schedule, TestCase
+from nnsmith.graph_gen import random_model_gen
+from nnsmith.materialize import Model, TestCase
 from nnsmith.materialize.tensorflow import TFModelCPU
 from nnsmith.narrow_spec import auto_opconfig, auto_opset
 
@@ -38,18 +38,12 @@ def test_synthesized_tf_model(tmp_path):
 
     gen = random_model_gen(
         opset=auto_opset(TFModelCPU, factory),
-        init_rank=4,
         seed=23132,
         max_nodes=4,
     )  # One op should not be easily wrong... I guess.
 
-    fixed_graph, concrete_abstensors = concretize_graph(
-        gen.abstract_graph, gen.tensor_dataflow, gen.get_solutions()
-    )
-
-    schedule = Schedule.init(fixed_graph, concrete_abstensors)
-
-    model = ModelType.from_schedule(schedule)
+    gen.ir.concretize(gen.get_sat_model())
+    model = ModelType.from_gir(gen.ir)
 
     # model.refine_weights()  # either random generated or gradient-based.
     oracle = model.make_oracle()

--- a/tests/torch/test_trt_backend.py
+++ b/tests/torch/test_trt_backend.py
@@ -8,8 +8,8 @@ if not GPUtil.getAvailable():
 
 from nnsmith.abstract.dtype import DType
 from nnsmith.backends import BackendFactory
-from nnsmith.graph_gen import concretize_graph, random_model_gen
-from nnsmith.materialize import Model, Schedule, TestCase
+from nnsmith.graph_gen import random_model_gen
+from nnsmith.materialize import Model, TestCase
 from nnsmith.narrow_spec import auto_opconfig, auto_opset
 
 TestCase.__test__ = False  # supress PyTest warning
@@ -43,18 +43,12 @@ def test_synthesized_onnx_model(tmp_path):
 
     gen = random_model_gen(
         opset=auto_opset(ONNXModel, factory),
-        init_rank=4,
         seed=23132,
         max_nodes=1,
     )  # One op should not be easily wrong... I guess.
 
-    fixed_graph, concrete_abstensors = concretize_graph(
-        gen.abstract_graph, gen.tensor_dataflow, gen.get_solutions()
-    )
-
-    schedule = Schedule.init(fixed_graph, concrete_abstensors)
-
-    model = ONNXModel.from_schedule(schedule)
+    gen.ir.concretize(gen.get_sat_model())
+    model = ONNXModel.from_gir(gen.ir)
 
     assert model.with_torch
 

--- a/tests/torch/test_tvm_backend.py
+++ b/tests/torch/test_tvm_backend.py
@@ -3,8 +3,8 @@ import tvm
 
 from nnsmith.abstract.dtype import DType
 from nnsmith.backends import BackendFactory
-from nnsmith.graph_gen import concretize_graph, random_model_gen
-from nnsmith.materialize import Model, Schedule, TestCase
+from nnsmith.graph_gen import random_model_gen
+from nnsmith.materialize import Model, TestCase
 from nnsmith.narrow_spec import auto_opconfig, auto_opset
 
 TestCase.__test__ = False  # supress PyTest warning
@@ -42,18 +42,12 @@ def test_synthesized_onnx_model(tmp_path):
 
     gen = random_model_gen(
         opset=auto_opset(ONNXModel, factory),
-        init_rank=4,
         seed=23132,
         max_nodes=1,
     )  # One op should not be easily wrong... I guess.
 
-    fixed_graph, concrete_abstensors = concretize_graph(
-        gen.abstract_graph, gen.tensor_dataflow, gen.get_solutions()
-    )
-
-    schedule = Schedule.init(fixed_graph, concrete_abstensors)
-
-    model = ONNXModel.from_schedule(schedule)
+    gen.ir.concretize(gen.get_sat_model())
+    model = ONNXModel.from_gir(gen.ir)
 
     assert model.with_torch
 


### PR DESCRIPTION
GraphIR is now integrated so that we now can do generation, mutation, translation, visualization (dot) in one self-hosted IR. 

Notably the dot lang is translated from GraphIR from scratch now so that we can customize the style and drop the networkx dependency.

As a sample:

![image](https://user-images.githubusercontent.com/38074777/203933013-299ba8a2-ea45-47da-af6f-4fdca9b35ba2.png)

Later on we need to also deprecate the `pygraphviz` dependency for its type constraints. We also need to update the developer doc for simplifying program manipulation and translation with GraphIR.