### PR TITLE
fix: adapt f16 relu

### DIFF
--- a/nnsmith/materialize/torch/numeric.py
+++ b/nnsmith/materialize/torch/numeric.py
@@ -12,6 +12,8 @@ def numeric_valid(outputs) -> bool:
 
 # generalized loss fn
 def smoothed_relu(x):
+    if x.dtype == torch.float16:
+        return torch.relu(x.float()).half()
     return torch.relu(x)
 
 


### PR DESCRIPTION
torch.relu do not natively support fp16 but is needed in gradient fn. Do a simple re-casting to make it work. 

*should have let it patched together with the last PR but forgot this part. 🤦‍♂️