### PR TITLE
fix: use torch.sigmoid over ..nn.functional.. suggested by torch

### DIFF
--- a/nnsmith/materialize/torch/forward.py
+++ b/nnsmith/materialize/torch/forward.py
@@ -56,7 +56,7 @@ def forward_fn(op: PReLU):
 
 @operator_impl(Sigmoid)
 def forward_fn(op: Sigmoid):
-    return torch.nn.functional.sigmoid
+    return torch.sigmoid
 
 
 @operator_impl(Sin)


### PR DESCRIPTION
OK, we respect PyTorch.

```
.../site-packages/torch/nn/functional.py:1967: UserWarning: nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
  warnings.warn("nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.")
```