### PR TITLE
[Torch][Codegen] SymbolNet -> `torch.fx.GraphModule`

### DIFF
--- a/nnsmith/backends/torchjit.py
+++ b/nnsmith/backends/torchjit.py
@@ -53,7 +53,7 @@ class TorchJITFactory(BackendFactory):
                 k: torch.from_numpy(v).to(self.device) for k, v in inputs.items()
             }
             with torch.no_grad():
-                output: Tuple[torch.Tensor] = exported(*input_ts.values())
+                output: Tuple[torch.Tensor] = exported(**input_ts)
             return {
                 k: v.cpu().detach().resolve_conj().numpy()
                 if v.is_conj()

--- a/nnsmith/backends/torchjit.py
+++ b/nnsmith/backends/torchjit.py
@@ -42,18 +42,19 @@ class TorchJITFactory(BackendFactory):
                     "ignore",
                     category=torch.jit.TracerWarning,
                 )
-                exported = torch.jit.trace(torch_net, trace_inp)
+                exported = torch.jit.trace(
+                    torch_net,
+                    trace_inp,
+                )
                 exported = torch.jit.freeze(exported)  # Fronzen graph.
                 exported = torch.jit.optimize_for_inference(exported)
                 if self.target == "cpu" and NNSMITH_PTJIT_OPT_MOBILE:
                     exported = optimize_for_mobile(exported)
 
         def closure(inputs: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
-            input_ts = {
-                k: torch.from_numpy(v).to(self.device) for k, v in inputs.items()
-            }
+            input_ts = [torch.from_numpy(v).to(self.device) for _, v in inputs.items()]
             with torch.no_grad():
-                output: Tuple[torch.Tensor] = exported(**input_ts)
+                output: Tuple[torch.Tensor] = exported(*input_ts)
             return {
                 k: v.cpu().detach().resolve_conj().numpy()
                 if v.is_conj()

--- a/nnsmith/materialize/torch/__init__.py
+++ b/nnsmith/materialize/torch/__init__.py
@@ -60,8 +60,9 @@ class TorchModel(Model, ABC):
                 inputs = self.torch_model.get_random_inps()
             else:
                 inputs = self.sat_inputs
-            inputs = {k: v.to(self.device()) for k, v in inputs.items()}
-            outputs = self.torch_model.forward(**inputs)
+            outputs = self.torch_model.forward(
+                *[v.to(self.device()) for _, v in inputs.items()]
+            )
 
         # numpyify
         input_dict = {k: v.cpu().detach().numpy() for k, v in inputs.items()}

--- a/nnsmith/materialize/torch/input_gen.py
+++ b/nnsmith/materialize/torch/input_gen.py
@@ -67,7 +67,7 @@ class SamplingSearch(InputSearchBase):
     def search_one(self, start_inp, timeout_ms: int = None) -> Dict[str, torch.Tensor]:
         with torch.no_grad():
             self.net.check_intermediate_numeric = True
-            _ = self.net(**start_inp)
+            _ = self.net(*start_inp.values())
             if not self.net.invalid_found_last:
                 return start_inp
 
@@ -94,7 +94,7 @@ class PracticalHybridSearch(InputSearchBase):
             diff_test_inp = self.net.get_random_inps(use_cuda=self.use_cuda)
             for _, item in diff_test_inp.items():
                 item.requires_grad_()
-            self.net.forward(**diff_test_inp)
+            self.net.forward(*diff_test_inp.values())
             self.differentiable = self.net.differentiable
         else:
             self.differentiable = False

--- a/nnsmith/materialize/torch/symbolnet.py
+++ b/nnsmith/materialize/torch/symbolnet.py
@@ -309,7 +309,7 @@ class SymbolNet(nn.Module):
             self.iter_num += 1
 
             try:
-                _ = self.forward_grad(**inputs)
+                _ = self.forward_grad(*inputs.values())
                 if self.invalid_found_last:  # need_to_train
                     self.backward()
                 else:
@@ -345,12 +345,12 @@ class SymbolNet(nn.Module):
     def use_cuda(self):
         self.cuda()
 
-    def forward(self, **kwargs):
+    def forward(self, *args):
         self.differentiable = True
 
         tensor_map: Dict[str, torch.Tensor] = {}
-        for key in list(self.input_map.keys()):
-            tensor_map[key] = kwargs[key]
+        for i, key in enumerate(self.input_map.keys()):
+            tensor_map[key] = args[i]
 
         debug_numeric(tensor_map)
 
@@ -378,12 +378,12 @@ class SymbolNet(nn.Module):
         self.first_run = False
         return tuple(tensor_map[key] for key in self.output_map)
 
-    def forward_grad(self, **kwargs):
+    def forward_grad(self, *args):
         self.differentiable = True
 
         tensor_map: Dict[str, torch.Tensor] = {}
-        for key in list(self.input_map.keys()):
-            tensor_map[key] = kwargs[key]
+        for i, key in enumerate(self.input_map.keys()):
+            tensor_map[key] = args[i]
 
         debug_numeric(tensor_map)
 


### PR DESCRIPTION
This PR allows symbolnet's forward function to be cleanly traced by `torch.fx.symbolic_trace` in order to create a `fx.GraphModule` which can dump model code --> an essential step for producing torch code at Python level to reproduce bugs.