### PR TITLE
[Backend] Support PyTorch 2.0 (aka `torch.compile`)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           pytest tests/torch
           yes | python nnsmith/cli/model_gen.py debug.viz=true model.type=torch mgen.method=symbolic
           yes | python nnsmith/cli/model_gen.py debug.viz=true model.type=torch mgen.method=symbolic-cinit
-          yes | python nnsmith/cli/model_gen.py debug.viz=true model.type=torch mgen.method=concolic
+          yes | python nnsmith/cli/model_gen.py debug.viz=true model.type=torch backend.type="pt2 backend@inductor" mgen.method=concolic
           yes | python nnsmith/cli/model_gen.py model.type=torch mgen.method=symbolic-cinit mgen.rank_choices="[4]" mgen.dtype_choices="[f32]" mgen.include="[core.NCHWConv2d, core.ReLU]" mgen.patch_requires=./tests/mock/requires_patch.py
           yes | python nnsmith/cli/model_gen.py model.type=torch mgen.method=symbolic-cinit mgen.rank_choices="[4]" mgen.dtype_choices="[f32]" mgen.include="[core.NCHWConv2d, core.ReLU]" mgen.patch_requires=./tests/mock/requires_patch.py backend.type=torchjit
       - name: Test ONNX + ONNXRuntime

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@
 
 <div align="center">
 
-| Models | [`tvm`](https://github.com/apache/tvm) | [`onnxruntime`](https://github.com/microsoft/onnxruntime) | [`tensorrt`](https://github.com/NVIDIA/TensorRT) | [`tflite`](https://www.tensorflow.org/lite) | [`xla`](https://www.tensorflow.org/xla) | [`torchjit`](https://pytorch.org/docs/stable/jit.html) |
-| ------------ | ------------------------------------ | ----------------------------------------------- | ---------------------------------------------- | ----------------------------------------- | ------------------------------------- | ----------------------------------------------------- |
-| ONNX         | ✅                                    | ✅                                               | ✅                                              |                                           |                                       |                                                       |
-| TensorFlow   | 🔨                                    |                                                 |                                                | ✅                                         | ✅                                     |                                                       |
-| PyTorch      | 🔨                                    |                                                 |                                                |                                           |                                       | ✅                                                     |
+| Models | [`tvm`](https://github.com/apache/tvm) | [`pt2`](https://pytorch.org/get-started/pytorch-2.0/) | [`torchjit`](https://pytorch.org/docs/stable/jit.html) | [`tensorrt`](https://github.com/NVIDIA/TensorRT) | [`onnxruntime`](https://github.com/microsoft/onnxruntime) | [`xla`](https://www.tensorflow.org/xla) | [`tflite`](https://www.tensorflow.org/lite) |
+| ------------ | ------------------------------------ | ----------------------------------------------- | ---------------------------------------------- | ----------------------------------------- | ------------------------------------- | ----------------------------------------------------- | ------------ |
+| ONNX         | ✅                                    |                                                |                                               | ✅ | ✅ |                                                       |  |
+| PyTorch | 🔨                                    | ✅ | ✅ |                                          |                                      |                                         |                                             |
+| TensorFlow | 🔨                                    |                                                       |                                                        |                                           |                                       | ✅                                                    | ✅ |
 
 ✅: Supported; 🔨: Coming soon;
+
 </div>
 
 ## Quick Start

--- a/nnsmith/backends/factory.py
+++ b/nnsmith/backends/factory.py
@@ -30,7 +30,7 @@ def parse_name_kwargs(text):
     if len(tokens) == 0:
         raise ValueError(f"Invalid backend: {text}. Expected format: {fmt}")
 
-    pattern = re.compile(r"[a-zA-Z0-9_]+")
+    pattern = re.compile(r"^[a-zA-Z0-9_]+$")
 
     name = tokens[0]
     if not pattern.match(name):

--- a/nnsmith/backends/factory.py
+++ b/nnsmith/backends/factory.py
@@ -356,51 +356,51 @@ class BackendFactory(ABC):
             kwargs.update(kw_dict)
 
         if name == "onnxruntime":
-            from nnsmith.backends.onnxruntime import ORTFactory
+            from nnsmith.backends.onnxruntime import ORT
 
-            return ORTFactory(
+            return ORT(
                 target=target,
                 optmax=optmax,
                 **kwargs,
             )
         elif name == "tvm":
-            from nnsmith.backends.tvm import TVMFactory
+            from nnsmith.backends.tvm import TVM
 
             # default executor is graph
             kwargs["executor"] = kwargs.get("executor", "graph")
-            return TVMFactory(
+            return TVM(
                 target=target,
                 optmax=optmax,
                 **kwargs,
             )
         elif name == "tensorrt":
-            from nnsmith.backends.tensorrt import TRTFactory
+            from nnsmith.backends.tensorrt import TRT
 
-            return TRTFactory(
+            return TRT(
                 target=target,
                 optmax=optmax,
                 **kwargs,
             )
         elif name == "tflite":
-            from nnsmith.backends.tflite import TFLiteFactory
+            from nnsmith.backends.tflite import TFLite
 
-            return TFLiteFactory(
+            return TFLite(
                 target=target,
                 optmax=optmax,
                 **kwargs,
             )
         elif name == "xla":
-            from nnsmith.backends.xla import XLAFactory
+            from nnsmith.backends.xla import XLA
 
-            return XLAFactory(
+            return XLA(
                 target=target,
                 optmax=optmax,
                 **kwargs,
             )
         elif name == "torchjit":
-            from nnsmith.backends.torchjit import TorchJITFactory
+            from nnsmith.backends.torchjit import TorchJIT
 
-            return TorchJITFactory(target=target, optmax=optmax, **kwargs)
+            return TorchJIT(target=target, optmax=optmax, **kwargs)
         elif name == "pt2":
             from nnsmith.backends.pt2 import PT2
 

--- a/nnsmith/backends/onnxruntime.py
+++ b/nnsmith/backends/onnxruntime.py
@@ -15,7 +15,7 @@ OPT_LEVELS = [
 ]
 
 
-class ORTFactory(BackendFactory):
+class ORT(BackendFactory):
     def __init__(self, target, optmax, **kwargs):
         """opt_level ranges from 0 to 3, stands for ORT_DISABLE_ALL, ORT_ENABLE_BASIC, ORT_ENABLE_EXTENDED and ORT_ENABLE_ALL.
         See https://onnxruntime.ai/docs/performance/graph-optimizations.html for detail"""

--- a/nnsmith/backends/pt2.py
+++ b/nnsmith/backends/pt2.py
@@ -1,0 +1,50 @@
+from typing import Dict, Tuple
+
+import numpy as np
+import torch
+from multipledispatch import dispatch
+
+from nnsmith.backends.factory import BackendCallable, BackendFactory
+from nnsmith.materialize.torch import TorchModel
+from nnsmith.materialize.torch.symbolnet import FxTracing
+
+
+class PT2(BackendFactory):
+    def __init__(self, target="cpu", optmax: bool = False, **kwargs):
+        super().__init__(target, optmax)
+        if self.target == "cpu":
+            self.device = torch.device("cpu")
+        elif self.target == "cuda":
+            self.device = torch.device("cuda")
+        else:
+            raise ValueError(
+                f"Unknown target: {self.target}. Only `cpu` and `cuda` are supported."
+            )
+
+        # get backend from kwargs or inductor by default
+        self.backend = kwargs.get("backend", "inductor")
+
+    @property
+    def system_name(self) -> str:
+        return "pt2"
+
+    @dispatch(TorchModel)
+    def make_backend(self, model: TorchModel) -> BackendCallable:
+        torch_net = model.torch_model.to(self.device).eval()
+        with torch.no_grad():
+            with FxTracing():
+                traced = torch.fx.symbolic_trace(torch_net)
+                compiled = torch.compile(traced, fullgraph=True, backend=self.backend)
+
+        def closure(inputs: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+            input_ts = [torch.from_numpy(v).to(self.device) for _, v in inputs.items()]
+            with torch.no_grad():
+                output: Tuple[torch.Tensor] = compiled(*input_ts)
+            return {
+                k: v.cpu().detach().resolve_conj().numpy()
+                if v.is_conj()
+                else v.cpu().detach().numpy()
+                for k, v in zip(torch_net.output_like.keys(), output)
+            }
+
+        return closure

--- a/nnsmith/backends/tensorrt.py
+++ b/nnsmith/backends/tensorrt.py
@@ -23,7 +23,7 @@ class HostDeviceMem:
     device: DeviceAllocation
 
 
-class TRTFactory(BackendFactory):
+class TRT(BackendFactory):
     def __init__(self, target="cuda", optmax=True, **kwargs):
         super().__init__(target, optmax, **kwargs)
 
@@ -148,6 +148,6 @@ class TRTFactory(BackendFactory):
         return [DType.float64, DType.int64]
 
 
-@patch_requires(TRTFactory.system_name, "core.Pool2d")
+@patch_requires(TRT.system_name, "core.Pool2d")
 def RulePool2d(self: AbsOpBase, _: List[AbsTensor]) -> List[Union[z3.BoolRef, bool]]:
     return [nnsmith_lt(nnsmith_mul(self.kernel_h_size, self.kernel_w_size), 10000)]

--- a/nnsmith/backends/tflite.py
+++ b/nnsmith/backends/tflite.py
@@ -18,7 +18,7 @@ class TFLiteRunner:
         return {k: np.array(v) for k, v in self.tfnet_callable(**input).items()}
 
 
-class TFLiteFactory(BackendFactory):
+class TFLite(BackendFactory):
     """Factory to build TFLite backend.
     Convertion Graph:
         TFModel & one concrete function

--- a/nnsmith/backends/torchjit.py
+++ b/nnsmith/backends/torchjit.py
@@ -15,7 +15,7 @@ from nnsmith.materialize.torch import TorchModel
 NNSMITH_PTJIT_OPT_MOBILE = os.getenv("NNSMITH_PTJIT_OPT_MOBILE", "0") == "1"
 
 
-class TorchJITFactory(BackendFactory):
+class TorchJIT(BackendFactory):
     def __init__(self, target="cpu", optmax: bool = False, **kwargs):
         super().__init__(target, optmax)
         if self.target == "cpu":

--- a/nnsmith/backends/tvm.py
+++ b/nnsmith/backends/tvm.py
@@ -20,7 +20,7 @@ def list_eq(a, b):
     return True
 
 
-class TVMFactory(BackendFactory):
+class TVM(BackendFactory):
     def __init__(self, target="cpu", optmax=True, executor="graph", **kwargs) -> None:
         super().__init__(target, optmax, **kwargs)
         # WARNING: setting opt_level 4 sometimes causes false alarms

--- a/nnsmith/backends/xla.py
+++ b/nnsmith/backends/xla.py
@@ -12,7 +12,7 @@ from nnsmith.materialize.tensorflow import (
 )
 
 
-class XLAFactory(BackendFactory):
+class XLA(BackendFactory):
     def __init__(self, target="cpu", optmax: bool = False):
         super().__init__(target, optmax)
 

--- a/nnsmith/cli/dtype_test.py
+++ b/nnsmith/cli/dtype_test.py
@@ -14,6 +14,7 @@ def main(cfg: DictConfig):
             name=backend_cfg["type"],
             target=backend_cfg["target"],
             optmax=backend_cfg["optmax"],
+            parse_name=True,
         )
     else:
         factory = None

--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -130,6 +130,7 @@ class FuzzingLoop:
             cfg["backend"]["type"],
             target=cfg["backend"]["target"],
             optmax=cfg["backend"]["optmax"],
+            parse_name=True,
         )
 
         model_cfg = self.cfg["model"]

--- a/nnsmith/cli/model_exec.py
+++ b/nnsmith/cli/model_exec.py
@@ -94,6 +94,7 @@ def verify_testcase(
             cmp_cfg["with"]["type"],
             target=cmp_cfg["with"]["target"],
             optmax=cmp_cfg["with"]["optmax"],
+            parse_name=True,
         )
         cmp_testcase = cmp_fac.make_testcase(
             testcase.model,
@@ -196,6 +197,7 @@ def main(cfg: DictConfig):
             cfg["backend"]["type"],
             target=cfg["backend"]["target"],
             optmax=cfg["backend"]["optmax"],
+            parse_name=True,
         )
 
         output_dir = None if output_dirs is None else output_dirs[i]

--- a/nnsmith/cli/model_gen.py
+++ b/nnsmith/cli/model_gen.py
@@ -35,6 +35,7 @@ def main(cfg: DictConfig):
             cfg["backend"]["type"],
             target=cfg["backend"]["target"],
             optmax=cfg["backend"]["optmax"],
+            parse_name=True,
         )
     else:
         factory = None

--- a/nnsmith/materialize/torch/forward.py
+++ b/nnsmith/materialize/torch/forward.py
@@ -304,7 +304,7 @@ def forward_fn(op: Reshape):
 
 @operator_impl(Flatten)
 def forward_fn(op: Flatten):
-    return torch.Tensor.flatten
+    return lambda x: x.flatten()
 
 
 @operator_impl(Transpose)
@@ -344,16 +344,17 @@ def forward_fn(op: TrilinearInterp):
 
 @operator_impl(Squeeze)
 def forward_fn(op: Squeeze):
-    if op.extra_attrs["reduce_dim"] is not None:
-        return lambda x: x.squeeze(op.extra_attrs["reduce_dim"])
-    return torch.Tensor.squeeze
+    v = op.extra_attrs["reduce_dim"]
+    args = [v] if v is not None else []
+    # API like `torch.Tensor.squeeze` is not supported by torch.fx for now.
+    return lambda x: x.squeeze(*args)
 
 
 @operator_impl(TorchReduceSum)
 def forward_fn(op: TorchReduceSum):
-    if op.extra_attrs["reduce_dim"] is not None:
-        return lambda x: x.sum(op.extra_attrs["reduce_dim"])
-    return torch.Tensor.sum
+    v = op.extra_attrs["reduce_dim"]
+    args = [v] if v is not None else []
+    return lambda x: x.sum(*args)
 
 
 # ReduceMin
@@ -361,7 +362,7 @@ def forward_fn(op: TorchReduceSum):
 def forward_fn(op: ReduceMin):
     if op.extra_attrs["reduce_dim"] is not None:
         return lambda x: x.min(op.extra_attrs["reduce_dim"]).values
-    return torch.Tensor.min
+    return lambda x: x.min()
 
 
 # ReduceMax
@@ -369,31 +370,31 @@ def forward_fn(op: ReduceMin):
 def forward_fn(op: ReduceMax):
     if op.extra_attrs["reduce_dim"] is not None:
         return lambda x: x.max(op.extra_attrs["reduce_dim"]).values
-    return torch.Tensor.max
+    return lambda x: x.max()
 
 
 # ReduceMean
 @operator_impl(ReduceMean)
 def forward_fn(op: ReduceMean):
-    if op.extra_attrs["reduce_dim"] is not None:
-        return lambda x: x.mean(op.extra_attrs["reduce_dim"])
-    return torch.Tensor.mean
+    v = op.extra_attrs["reduce_dim"]
+    args = [v] if v is not None else []
+    return lambda x: x.mean(*args)
 
 
 # ArgMin
 @operator_impl(ArgMin)
 def forward_fn(op: ArgMin):
-    if op.extra_attrs["reduce_dim"] is not None:
-        return lambda x: x.argmin(op.extra_attrs["reduce_dim"])
-    return torch.Tensor.argmin
+    v = op.extra_attrs["reduce_dim"]
+    args = [v] if v is not None else []
+    return lambda x: x.argmin(*args)
 
 
 # ArgMax
 @operator_impl(ArgMax)
 def forward_fn(op: ArgMax):
-    if op.extra_attrs["reduce_dim"] is not None:
-        return lambda x: x.argmax(op.extra_attrs["reduce_dim"])
-    return torch.Tensor.argmax
+    v = op.extra_attrs["reduce_dim"]
+    args = [v] if v is not None else []
+    return lambda x: x.argmax(*args)
 
 
 # Tril

--- a/tests/core/test_parse_name_kwargs.py
+++ b/tests/core/test_parse_name_kwargs.py
@@ -1,0 +1,69 @@
+import pytest
+
+from nnsmith.backends.factory import parse_name_kwargs
+
+
+def test_single_invalid():
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("+")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("@something")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("something@")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("pt2@something")
+
+
+def test_single_valid():
+    assert parse_name_kwargs("pt2") == ("pt2", {})
+    assert parse_name_kwargs("pt2 ") == ("pt2", {})
+    assert parse_name_kwargs("pt2   ") == ("pt2", {})
+    assert parse_name_kwargs(" pt2") == ("pt2", {})
+    assert parse_name_kwargs("  pt2") == ("pt2", {})
+    assert parse_name_kwargs("  pt2  ") == ("pt2", {})
+
+
+def test_kwargs_invalid():
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("pt2 foo")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("pt2 foo@")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("pt2 @bar")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("pt2 foo@bar baz")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("pt2 foo@ qux")
+
+    with pytest.raises(ValueError, match="Invalid backend"):
+        parse_name_kwargs("pt2 foo@@qux")
+
+
+def test_kwargs_valid():
+    assert parse_name_kwargs("pt2 foo@bar") == ("pt2", {"foo": "bar"})
+
+    assert parse_name_kwargs("pt2 foo@bar baz@qux") == (
+        "pt2",
+        {"foo": "bar", "baz": "qux"},
+    )
+
+    assert parse_name_kwargs("pt2 foo@bar baz@qux quux@quuz") == (
+        "pt2",
+        {"foo": "bar", "baz": "qux", "quux": "quuz"},
+    )
+
+    # add a few random space
+    assert parse_name_kwargs("pt2 foo@bar baz@qux  quux@quuz") == (
+        "pt2",
+        {"foo": "bar", "baz": "qux", "quux": "quuz"},
+    )

--- a/tests/torch/test_pt2_backend.py
+++ b/tests/torch/test_pt2_backend.py
@@ -1,0 +1,57 @@
+import pytest
+import torch
+
+from nnsmith.abstract.dtype import DType
+from nnsmith.backends import BackendFactory
+from nnsmith.graph_gen import model_gen
+from nnsmith.materialize import Model, TestCase
+from nnsmith.narrow_spec import auto_opconfig, auto_opset
+
+TestCase.__test__ = False  # supress PyTest warning
+
+
+def test_narrow_spec_cache_make_and_reload():
+    factory = BackendFactory.init("pt2", target="cpu", optmax=True)
+    ModelType = Model.init("torch")
+    opset_lhs = auto_opconfig(ModelType, factory)
+    assert opset_lhs, "Should not be empty... Something must go wrong."
+    opset_rhs = auto_opconfig(ModelType, factory)
+    assert opset_lhs == opset_rhs
+
+    # Assert types
+    assert isinstance(opset_lhs["core.ReLU"].in_dtypes[0][0], DType)
+
+    # Assert Dictionary Type Equality
+    assert type(opset_lhs) == type(opset_rhs)
+    assert type(opset_lhs["core.ReLU"]) == type(opset_rhs["core.ReLU"])
+    assert type(opset_lhs["core.ReLU"].in_dtypes[0][0]) == type(
+        opset_rhs["core.ReLU"].in_dtypes[0][0]
+    )
+
+
+def test_synthesized_tf_model(tmp_path):
+    d = tmp_path / "test_pt2"
+    d.mkdir()
+
+    targets = ["cpu"]
+    if torch.cuda.is_available():
+        targets.append("cuda")
+
+    for target in targets:
+        factory = BackendFactory.init("pt2", target=target, optmax=False)
+
+        ModelType = Model.init("torch", backend_target=target)
+
+        gen = model_gen(
+            opset=auto_opset(ModelType, factory),
+            seed=23132,
+            max_nodes=1,
+        )  # One op should not be easily wrong... I guess.
+
+        model = ModelType.from_gir(gen.make_concrete())
+
+        oracle = model.make_oracle()
+
+        testcase = TestCase(model, oracle)
+        assert factory.verify_testcase(testcase) is None
+        testcase.dump(root_folder=d)


### PR DESCRIPTION
With the workaround to convert `SymbolNet -> torch.fx.GraphModule` (#101), we can do `torch.compile` without graph break (aka: `full_graph=True`) to allow best optimization! 

This PR basically adds:
1. supports for using `pt2` as the backend
2. implemented simple regex-based parser to parse `backend.type` so that we can directly create some "kwargs" to pass through the compiler backend. 

The grammar is like `<NAME> <key1>@<value1> <key2>@<value2> ...`. For example, `... backend.type="pt2 backend@inductor" ...` let the backend of `torch.compile` to be `inductor`.