### PR TITLE
[DRAFT][UX] Bug report/test-case rendering for PyTorch

### DIFF
--- a/nnsmith/abstract/__init__.py
+++ b/nnsmith/abstract/__init__.py
@@ -1,0 +1,3 @@
+from .dtype import *
+from .op import *
+from .tensor import *

--- a/nnsmith/abstract/op.py
+++ b/nnsmith/abstract/op.py
@@ -703,12 +703,12 @@ class Placeholder:
     def __repr__(self):
         return f"Placeholder({self.ttype})"
 
-    def as_input(self):
+    def const(self):
         const_node = Constant(self.ttype.ndims)
         const_node.abs_tensor = self.ttype
         return const_node
 
-    def as_input(self):
+    def input(self):
         input_node = Input(self.ttype.ndims)
         input_node.abs_tensor = self.ttype
         return input_node

--- a/nnsmith/abstract/op.py
+++ b/nnsmith/abstract/op.py
@@ -21,12 +21,6 @@ from nnsmith.abstract.extension import ACTIVATED_PATCH
 from nnsmith.abstract.tensor import AbsTensor
 from nnsmith.error import ConstraintCheck, SanityCheck
 
-# There are following types of constraints at this point:
-# 1. Shape variables must be greater than 0;
-# 2. Shape variables must avoid devision by 0;
-# 3. Extra constraints introduced by individual operators;
-
-
 __MIN_RANK__ = 0
 __MAX_RANK__ = 5
 
@@ -709,12 +703,12 @@ class Placeholder:
     def __repr__(self):
         return f"Placeholder({self.ttype})"
 
-    def to_const(self):
+    def as_input(self):
         const_node = Constant(self.ttype.ndims)
         const_node.abs_tensor = self.ttype
         return const_node
 
-    def to_input(self):
+    def as_input(self):
         input_node = Input(self.ttype.ndims)
         input_node.abs_tensor = self.ttype
         return input_node
@@ -890,14 +884,14 @@ class Pool2d(UnaryOpBase):
 
     def __init__(
         self,
-        kernel_h_size: Union[int, z3.ExprRef],
-        kernel_w_size: Union[int, z3.ExprRef],
+        kh: Union[int, z3.ExprRef],
+        kw: Union[int, z3.ExprRef],
         stride: Union[int, z3.ExprRef],
         padding: Union[int, z3.ExprRef],
     ):
         super().__init__()
-        self.kernel_h_size = kernel_h_size
-        self.kernel_w_size = kernel_w_size
+        self.kh = kh
+        self.kw = kw
         self.stride = stride
         self.padding = padding
 
@@ -905,7 +899,6 @@ class Pool2d(UnaryOpBase):
         self.out_ranks = [(4,)]  # NCHW
 
     def type_transfer(self, input_shapes: List[AbsTensor]) -> List[AbsTensor]:
-
         abs_tensor = AbsTensor([], dtype=input_shapes[0].dtype)
         # Batch dim: just copy
         abs_tensor.shape.append(input_shapes[0].shape[0])
@@ -915,7 +908,7 @@ class Pool2d(UnaryOpBase):
             (
                 nnsmith_div(
                     nnsmith_add(
-                        nnsmith_sub(input_shapes[0].shape[2], self.kernel_h_size),
+                        nnsmith_sub(input_shapes[0].shape[2], self.kh),
                         2 * self.padding,
                     ),
                     self.stride,
@@ -927,7 +920,7 @@ class Pool2d(UnaryOpBase):
             (
                 nnsmith_div(
                     nnsmith_add(
-                        nnsmith_sub(input_shapes[0].shape[3], self.kernel_w_size),
+                        nnsmith_sub(input_shapes[0].shape[3], self.kw),
                         2 * self.padding,
                     ),
                     self.stride,
@@ -940,29 +933,29 @@ class Pool2d(UnaryOpBase):
     def requires(self, input_shapes):
         cons = []
         ret = []
-        cons.append(nnsmith_ge(self.kernel_h_size, 1))
-        cons.append(nnsmith_ge(self.kernel_w_size, 1))
+        cons.append(nnsmith_ge(self.kh, 1))
+        cons.append(nnsmith_ge(self.kw, 1))
         cons.append(
             nnsmith_le(
-                self.kernel_h_size,
+                self.kh,
                 nnsmith_add(input_shapes[0].shape[2], 2 * self.padding),
             )
         )
         cons.append(
             nnsmith_le(
-                self.kernel_w_size,
+                self.kw,
                 nnsmith_add(input_shapes[0].shape[3], 2 * self.padding),
             )
         )
         cons.append(nnsmith_ge(self.stride, 1))
         cons.append(nnsmith_ge(self.padding, 0))
-        # not too extream to avoid torch exporter issue
+        # Not too extreme to avoid torch exporter issue
         cons.append(nnsmith_le(self.padding, 255))
-        cons.append(nnsmith_le(self.padding, nnsmith_div(self.kernel_h_size, 2)))
-        cons.append(nnsmith_le(self.padding, nnsmith_div(self.kernel_w_size, 2)))
+        cons.append(nnsmith_le(self.padding, nnsmith_div(self.kh, 2)))
+        cons.append(nnsmith_le(self.padding, nnsmith_div(self.kw, 2)))
         cons.extend(
             [nnsmith_gt(v, 0) for v in input_shapes[0].shape]
-        )  # dim cannot be 0 for maxpool
+        )  # Dims cannot be 0 for MaxPool
 
         for c in cons:
             ret.append(c)

--- a/nnsmith/backends/factory.py
+++ b/nnsmith/backends/factory.py
@@ -339,6 +339,17 @@ class BackendFactory(ABC):
             model, Oracle(input=input, output=output, provider=self.system_name)
         )
 
+    @property
+    @abstractmethod
+    def import_libs(self) -> List[str]:
+        pass
+
+    def emit_compile(self, opt_name: str, mod_name: str) -> str:
+        raise NotImplementedError
+
+    def emit_run(self, out_name: str, opt_name: str, inp_name: str) -> str:
+        raise NotImplementedError
+
     @staticmethod
     def init(
         name: str, target: str = "cpu", optmax: bool = True, parse_name=False, **kwargs

--- a/nnsmith/backends/factory.py
+++ b/nnsmith/backends/factory.py
@@ -50,7 +50,7 @@ def parse_name_kwargs(text):
 
 
 class BackendFactory(ABC):
-    def __init__(self, target="cpu", optmax: bool = False):
+    def __init__(self, target="cpu", optmax: bool = True):
         super().__init__()
         self.target = target
         self.optmax = optmax

--- a/nnsmith/backends/onnxruntime.py
+++ b/nnsmith/backends/onnxruntime.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import onnx
 import onnxruntime as ort
 from multipledispatch import dispatch
@@ -18,7 +20,8 @@ OPT_LEVELS = [
 class ORT(BackendFactory):
     def __init__(self, target, optmax, **kwargs):
         """opt_level ranges from 0 to 3, stands for ORT_DISABLE_ALL, ORT_ENABLE_BASIC, ORT_ENABLE_EXTENDED and ORT_ENABLE_ALL.
-        See https://onnxruntime.ai/docs/performance/graph-optimizations.html for detail"""
+        See https://onnxruntime.ai/docs/performance/graph-optimizations.html for detail
+        """
         super().__init__(target, optmax, **kwargs)
         self.opt_level = OPT_LEVELS[-1 if optmax else 0]
 
@@ -41,6 +44,10 @@ class ORT(BackendFactory):
     @property
     def version(self) -> str:
         return ort.__version__
+
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import onnxruntime as ort"]
 
     @dispatch(ONNXModel)
     def make_backend(

--- a/nnsmith/backends/pt2.py
+++ b/nnsmith/backends/pt2.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 import torch
@@ -28,6 +28,10 @@ class PT2(BackendFactory):
     @property
     def system_name(self) -> str:
         return "pt2"
+
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import torch"]
 
     @dispatch(TorchModel)
     def make_backend(self, model: TorchModel) -> BackendCallable:

--- a/nnsmith/backends/pt2.py
+++ b/nnsmith/backends/pt2.py
@@ -10,7 +10,7 @@ from nnsmith.materialize.torch.symbolnet import FxTracing
 
 
 class PT2(BackendFactory):
-    def __init__(self, target="cpu", optmax: bool = False, **kwargs):
+    def __init__(self, target: str = "cpu", optmax: bool = True, **kwargs):
         super().__init__(target, optmax)
         if self.target == "cpu":
             self.device = torch.device("cpu")
@@ -55,3 +55,12 @@ class PT2(BackendFactory):
             }
 
         return closure
+
+    def emit_compile(self, opt_name: str, mod_name: str) -> str:
+        mode = f"'{self.mode}'" if self.mode else "None"
+        return f"{opt_name} = torch.compile({mod_name}, fullgraph=True, backend='{self.backend}', mode={mode})"
+
+    def emit_run(self, out_name: str, opt_name: str, inp_name: str) -> str:
+        return f"""{out_name} = {opt_name}(*[torch.from_numpy(v).to('{self.device.type}') for v in {inp_name}])
+{out_name} = [v.cpu().detach() for v in {out_name}] # torch2numpy
+{out_name} = [v.resolve_conj().numpy() if v.is_conj() else v.numpy() for v in {out_name}] # torch2numpy"""

--- a/nnsmith/backends/tensorrt.py
+++ b/nnsmith/backends/tensorrt.py
@@ -142,6 +142,10 @@ class TRT(BackendFactory):
         # Return only the host outputs.
         return [out.host for out in outputs]
 
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import tensorrt as trt"]
+
     @classmethod
     def skip_dtypes(cls) -> List[DType]:
         # TRT will truncate f64 -> f32 and i64 -> i32

--- a/nnsmith/backends/tflite.py
+++ b/nnsmith/backends/tflite.py
@@ -156,6 +156,10 @@ class TFLite(BackendFactory):
     def load_backend(self, path: PathLike) -> BackendCallable:
         return self.make_backend_from_content(self.load_content(path))
 
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import tensorflow as tf"]
+
     @classmethod
     def skip_dtypes(cls) -> List[DType]:
         # PyTorch-ONNX current does not support fully complex (e.g., scalar).

--- a/nnsmith/backends/torchjit.py
+++ b/nnsmith/backends/torchjit.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 import torch
@@ -63,3 +63,7 @@ class TorchJIT(BackendFactory):
             }
 
         return closure
+
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import torch"]

--- a/nnsmith/backends/tvm.py
+++ b/nnsmith/backends/tvm.py
@@ -22,7 +22,13 @@ def list_eq(a, b):
 
 
 class TVM(BackendFactory):
-    def __init__(self, target="cpu", optmax=True, executor="graph", **kwargs) -> None:
+    def __init__(
+        self,
+        target: str = "cpu",
+        optmax: bool = True,
+        executor: str = "graph",
+        **kwargs,
+    ) -> None:
         super().__init__(target, optmax, **kwargs)
         # WARNING: setting opt_level 4 sometimes causes false alarms
         # as in this level fast_math is enabled where slight numerical

--- a/nnsmith/backends/tvm.py
+++ b/nnsmith/backends/tvm.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 import tvm
 from multipledispatch import dispatch
@@ -84,6 +85,10 @@ class TVM(BackendFactory):
             return dict(zip(model.output_like.keys(), output))
 
         return closure
+
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import tvm"]
 
     @property
     def version(self) -> str:

--- a/nnsmith/backends/xla.py
+++ b/nnsmith/backends/xla.py
@@ -13,7 +13,7 @@ from nnsmith.materialize.tensorflow import (
 
 
 class XLA(BackendFactory):
-    def __init__(self, target="cpu", optmax: bool = False):
+    def __init__(self, target="cpu", optmax: bool = True):
         super().__init__(target, optmax)
 
         if self.target == "cpu":

--- a/nnsmith/backends/xla.py
+++ b/nnsmith/backends/xla.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 import tensorflow as tf  # type: ignore
 from multipledispatch import dispatch
@@ -35,6 +35,10 @@ class XLA(BackendFactory):
     @property
     def version(self) -> str:
         return tf.__version__
+
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import tensorflow as tf"]
 
     @dispatch(TFModel)
     def make_backend(self, model: TFModel) -> BackendCallable:

--- a/nnsmith/gir.py
+++ b/nnsmith/gir.py
@@ -247,8 +247,8 @@ class GraphIR:
 
     def replace_alluse(self, oldvar: str, newvar: str, type_check=True) -> None:
         # Change one variable to another new variable.
-        assert oldvar in self.vars, "oldvar not defined: " + oldvar
-        assert newvar in self.vars, "newvar not defined: " + newvar
+        assert oldvar in self.vars, "Old var undefined: " + oldvar
+        assert newvar in self.vars, "New var undefined: " + newvar
         # check type
         if (
             type_check
@@ -261,7 +261,7 @@ class GraphIR:
         # 1. replace all user site of oldvar to newvar.
         old_inst_id, old_ret_idx = InstIR.var_inst_idx(oldvar)
         old_inst = self.find_inst_by_id(old_inst_id)
-        assert old_inst is not None, "oldvar not defined: " + oldvar
+        assert old_inst is not None, "Old var undefined: " + oldvar
         for ouser in old_inst.users[old_ret_idx]:
             # change all use of oldvar to newvar
             ouser.iexpr.args = [newvar if a == oldvar else a for a in ouser.iexpr.args]
@@ -273,7 +273,7 @@ class GraphIR:
 
     def replace_arg(self, inst: InstIR, arg_idx: int, newvar: str, type_check=True):
         # Change one variable to another new variable.
-        assert newvar in self.vars, "newvar not defined: " + newvar
+        assert newvar in self.vars, "New var undefined: " + newvar
         assert (
             0 <= arg_idx < len(inst.iexpr.args)
         ), f"Invalid argument index {arg_idx} for {inst}"
@@ -332,7 +332,7 @@ class GraphIR:
 
             for rv in inst.retvals():
                 assert rv in self.vars, f"Return var not in self.vars: {rv}"
-                assert rv not in defined, f"Variable defined twice: {rv}"
+                assert rv not in defined, f"Variable re-defined: {rv}"
 
             # check user.
             for ret_idx, users in enumerate(inst.users):

--- a/nnsmith/graph_gen.py
+++ b/nnsmith/graph_gen.py
@@ -197,9 +197,9 @@ class BaseGen:
             ph_inst_id, _ = InstIR.var_inst_idx(ph)
             ph_inst = self.ir.find_inst_by_id(ph_inst_id)
             if to_input:
-                ph_inst.iexpr.op = ph_inst.iexpr.op.as_input()
+                ph_inst.iexpr.op = ph_inst.iexpr.op.input()
             else:
-                ph_inst.iexpr.op = ph_inst.iexpr.op.as_input()
+                ph_inst.iexpr.op = ph_inst.iexpr.op.const()
 
         determine_ph_type(self.placeholders[0], True)  # At lease make one input.
         for ph in self.placeholders[1:]:

--- a/nnsmith/graph_gen.py
+++ b/nnsmith/graph_gen.py
@@ -197,9 +197,9 @@ class BaseGen:
             ph_inst_id, _ = InstIR.var_inst_idx(ph)
             ph_inst = self.ir.find_inst_by_id(ph_inst_id)
             if to_input:
-                ph_inst.iexpr.op = ph_inst.iexpr.op.to_input()
+                ph_inst.iexpr.op = ph_inst.iexpr.op.as_input()
             else:
-                ph_inst.iexpr.op = ph_inst.iexpr.op.to_const()
+                ph_inst.iexpr.op = ph_inst.iexpr.op.as_input()
 
         determine_ph_type(self.placeholders[0], True)  # At lease make one input.
         for ph in self.placeholders[1:]:
@@ -606,7 +606,8 @@ class SymbolicGen(BaseGen):
 
 class ConcolicGen(BaseGen):
     """Different from SymbolicGen, the graph after an insertion is `concrete` in ConcolicGen.
-    However, each step when inserting a node, we symbolically find a satisfiable solution for it."""
+    However, each step when inserting a node, we symbolically find a satisfiable solution for it.
+    """
 
     def __init__(
         self,

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -470,7 +470,7 @@ class Render:
 
     def render(self) -> str:
         text = self.template
-        dedup_imports = list(set(self.imports))
+        deduplicate_imports = list(set(self.imports))
 
         def wrap(text, dependencies=None):
             if text is None:
@@ -479,7 +479,7 @@ class Render:
                 raise ValueError("Render failure: some dependencies are missing")
             return text
 
-        text = text.replace(self._IMPORTS, "\n".join(dedup_imports))
+        text = text.replace(self._IMPORTS, "\n".join(deduplicate_imports))
         text = text.replace(self._DEF, self.def_code)  # Mandatory
         text = text.replace(self._MAKE_WEIGHT, wrap(self.weight_code))
         text = text.replace(self._COMPILE, wrap(self.compile_code))

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -500,8 +500,7 @@ class Render:
 
         check_text = (
             f"""for i, (l, r) in enumerate(zip({self.eager_result_name}, {self.compile_result_name})):
-    np.testing.assert_allclose(l, r, rtol=1e-2, atol=1e-3, err_msg=f"Result mismatch @ index {{i}}")
-"""
+    np.testing.assert_allclose(l, r, rtol=1e-2, atol=1e-3, err_msg=f"Result mismatch @ index {{i}}")"""
             if self.eager_run_code and self.compile_run_code
             else None
         )

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import json
 import os
 import pickle
 from abc import ABC, abstractmethod
 from enum import Enum
 from os import PathLike
-from typing import Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar
+
+# Enables type checking while avoiding circular imports.
+if TYPE_CHECKING:
+    from nnsmith.backends import BackendFactory
 
 import numpy as np
 from multipledispatch import dispatch
@@ -177,6 +183,23 @@ class Model(ABC):
     def skip_dtypes() -> List[DType]:
         return []
 
+    @property
+    @abstractmethod
+    def import_libs(self) -> List[str]:
+        pass
+
+    def emit_def(self, mod_name: str, mod_cls: str) -> str:
+        raise NotImplementedError
+
+    def emit_run(self, out_name: str, inp_name: str, mod_name: str) -> str:
+        raise NotImplementedError
+
+    def emit_weight(self, mod_name: str, path: Optional[PathLike] = None):
+        raise NotImplementedError
+
+    def emit_input(self, inp_name: str, path: Optional[PathLike] = None):
+        raise NotImplementedError
+
     @staticmethod
     def init(name, backend_target=None) -> Type["Model"]:
         if name is None:
@@ -287,7 +310,7 @@ class BugReport(ABC):
     def __repr__(self) -> str:
         return f"{self.system} {self.symptom.value} in {self.stage.value}\n{self.log}"
 
-    def dump(self, root_folder: str):
+    def dump(self, root_folder: PathLike):
         # create folder if not exists
         if not os.path.exists(root_folder):
             os.makedirs(root_folder)
@@ -313,7 +336,6 @@ class BugReport(ABC):
 
     @staticmethod
     def load(model_type, root_folder: str, allow_partial=False) -> "BugReport":
-
         symptom = None
         stage = None
         version = None
@@ -342,3 +364,140 @@ class BugReport(ABC):
                 log = f.read()
 
         return BugReport(testcase, symptom, stage, system, version, version_id, log)
+
+
+class Render:
+    _IMPORTS = r"${{IMPORTS}}$"
+    _DEF = r"${{DEF}}$"
+    _MAKE_WEIGHT = r"${{MAKE_WEIGHT}}$"
+    _EAGER_RUN = r"${{EAGER_RUN}}$"
+    _COMPILE = r"${{COMPILE}}$"
+    _MAKE_INPUT = r"${{MAKE_INPUT}}$"
+    _COMPILE_RUN = r"${{COMPILE_RUN}}$"
+    _CHECK = r"${{CHECK}}$"
+
+    def __init__(
+        self,
+        template: Optional[str] = None,
+        mod_name="m",
+        mod_cls="M",
+        opt_name="opt",
+    ) -> None:
+        self.template = (
+            f"""
+{Render._IMPORTS}
+
+# Model definition
+{Render._DEF}
+
+# Initialize weight
+{Render._MAKE_WEIGHT}
+
+# Compile the model
+{Render._COMPILE}
+
+# Initialize input
+{Render._MAKE_INPUT}
+
+# Eager run
+{Render._EAGER_RUN}
+
+# Compiled run
+{Render._COMPILE_RUN}
+
+# Differential testing
+{Render._CHECK}
+"""
+            if template is None
+            else template
+        )
+        self.mod_name = mod_name
+        self.mod_cls = mod_cls
+        self.opt_name = opt_name
+
+        self.inp_name = "inp"
+        self.eager_result_name = f"{self.mod_name}_out"
+        self.compile_result_name = f"{self.opt_name}_out"
+
+        self.imports = ["import numpy as np"]
+        self.def_code: Optional[str] = None
+        self.weight_code: Optional[str] = None
+        self.compile_code: Optional[str] = None
+        self.input_code: Optional[str] = None
+        self.eager_run_code: Optional[str] = None
+        self.compile_run_code: Optional[str] = None
+        self.check_code: Optional[str] = None
+
+    def emit_model(self, model: Model):
+        self.imports.extend(model.import_libs)
+
+        # Define the model like:
+        #    class M(nn.Module): ...
+        # Initialize an instance:
+        #    m = M()
+        self.def_code = model.emit_def(mod_name=self.mod_name, mod_cls=self.mod_cls)
+
+        # Compute ${self.mod_name} eagerly over ${self.inp_name}
+        # and store the result in ${self.eager_result_name}
+        self.eager_run_code = model.emit_run(
+            out_name=self.eager_result_name,
+            mod_name=self.mod_name,
+            inp_name=self.inp_name,
+        )
+
+    def emit_weight(self, model: Model, path: Optional[PathLike] = None):
+        # Load the model weights from ${path}
+        self.weight_code = model.emit_weight(mod_name=self.mod_name, path=path)
+
+    def emit_input(self, model: Model, path: Optional[PathLike] = None):
+        # Load the model weights from ${path}
+        self.input_code = model.emit_input(inp_name=self.inp_name, path=path)
+
+    def emit_backend(self, backend: BackendFactory):
+        self.imports.extend(backend.import_libs)
+
+        # Compile the ${self.mod_name} to ${self.opt_name}
+        self.compile_code = backend.emit_compile(
+            opt_name=self.opt_name, mod_name=self.mod_name
+        )
+        # Run the compiled ${self.opt_name} over ${self.inp_name}
+        # and store the result in ${self.compile_result_name}
+        self.compile_run_code = backend.emit_run(
+            out_name=self.compile_result_name,
+            opt_name=self.opt_name,
+            inp_name=self.inp_name,
+        )
+
+    def render(self) -> str:
+        text = self.template
+        dedup_imports = list(set(self.imports))
+
+        def wrap(text, dependencies=None):
+            if text is None:
+                return "# None"
+            if dependencies is not None and not all(dependencies):
+                raise ValueError("Render failure: some dependencies are missing")
+            return text
+
+        text = text.replace(self._IMPORTS, "\n".join(dedup_imports))
+        text = text.replace(self._DEF, self.def_code)  # Mandatory
+        text = text.replace(self._MAKE_WEIGHT, wrap(self.weight_code))
+        text = text.replace(self._COMPILE, wrap(self.compile_code))
+        text = text.replace(self._MAKE_INPUT, wrap(self.input_code))
+        # To run a model eagerly we need the input data (`input_code`) to be available.
+        text = text.replace(
+            self._EAGER_RUN, wrap(self.eager_run_code, [self.input_code])
+        )
+        # To run a compiled model we need the model compiled (`compile_code`) and
+        # the input data (`input_code`) to be available.
+        text = text.replace(
+            self._COMPILE_RUN,
+            wrap(self.compile_run_code, [self.input_code, self.compile_code]),
+        )
+        check_text = f"""for i, (l, r) in enumerate(zip({self.eager_result_name}, {self.compile_result_name})):
+    np.testing.assert_allclose(l, r, rtol=1e-2, atol=1e-3, err_msg=f"Result mismatch @ index {{i}}")
+"""
+        text = text.replace(
+            self._CHECK, wrap(check_text, [self.eager_run_code, self.compile_run_code])
+        )
+        return text

--- a/nnsmith/materialize/tensorflow/__init__.py
+++ b/nnsmith/materialize/tensorflow/__init__.py
@@ -199,6 +199,10 @@ class TFModel(Model, ABC):  # Don't directly instantiate this class
     def operators() -> List[Type[AbsOpBase]]:
         return list(ALL_TF_OPS)
 
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import tensorflow as tf"]
+
     @staticmethod
     def add_seed_setter() -> None:
         register_seed_setter("tensorflow", tf.random.set_seed, overwrite=True)

--- a/nnsmith/materialize/torch/__init__.py
+++ b/nnsmith/materialize/torch/__init__.py
@@ -115,6 +115,10 @@ class TorchModel(Model, ABC):
     def operators() -> List[Type[AbsOpBase]]:
         return ALL_TORCH_OPS
 
+    @property
+    def import_libs(self) -> List[str]:
+        return ["import torch"]
+
     @staticmethod
     def add_seed_setter() -> None:
         register_seed_setter("torch", torch.manual_seed, overwrite=True)

--- a/nnsmith/materialize/torch/__init__.py
+++ b/nnsmith/materialize/torch/__init__.py
@@ -1,17 +1,54 @@
+import inspect
 import pickle
 from abc import ABC, abstractmethod
 from os import PathLike
-from typing import Dict, List, Type
+from typing import Dict, List, Optional, Type
 
 import torch
+from torch import fx, nn
 
 from nnsmith.abstract.op import AbsOpBase, AbsTensor
 from nnsmith.gir import GraphIR
 from nnsmith.materialize import Model, Oracle
 from nnsmith.materialize.torch.forward import ALL_TORCH_OPS
 from nnsmith.materialize.torch.input_gen import PracticalHybridSearch
-from nnsmith.materialize.torch.symbolnet import SymbolNet
+from nnsmith.materialize.torch.symbolnet import FxTracing, SymbolNet
 from nnsmith.util import register_seed_setter
+
+
+# FIXME(@ganler): handle (Sequential, ModuleList, ModuleDict) precisely
+# FIXME(@ganler): experimental; May not work.
+def _safe_repr(mod: nn.Module):
+    if isinstance(mod, (nn.Sequential, nn.ModuleList, nn.ModuleDict)):
+        return False
+    # Heuristic 2: multi-line repr
+    if mod.__repr__().count("\n") > 0:
+        return False
+    return True
+
+
+def _render_constructor(name: str, mod: nn.Module):
+    if _safe_repr(mod):
+        return f"torch.nn.{mod.__repr__()}"
+
+    # Hacks
+    if isinstance(mod, nn.MultiheadAttention):
+        kvs = {
+            "embed_dim": mod.embed_dim,
+            "num_heads": mod.num_heads,
+            "dropout": mod.dropout,
+            "bias": mod.in_proj_bias is not None,
+            "add_bias_kv": mod.bias_k is not None,
+            "add_zero_attn": mod.add_zero_attn,
+            "kdim": mod.kdim,
+            "vdim": mod.vdim,
+            "batch_first": mod.batch_first,
+        }
+        sig = inspect.signature(nn.MultiheadAttention)
+        kvs = {k: v for k, v in kvs.items() if sig.parameters[k].default != v}
+        return f"torch.nn.MultiheadAttention({ ', '.join(f'{k}={v}' for k, v in kvs.items()) })"
+
+    return f"torch.load('{name}.pth') # {type(mod).__name__}"
 
 
 class TorchModel(Model, ABC):
@@ -117,7 +154,50 @@ class TorchModel(Model, ABC):
 
     @property
     def import_libs(self) -> List[str]:
-        return ["import torch"]
+        return ["import torch", "import numpy as np", "import pickle"]
+
+    def emit_input(self, inp_name: str, path: Optional[PathLike] = None):
+        if path is not None:  # Assume NumPy tensors as inputs
+            return f"{inp_name} = [v for _, v in pickle.load(open('{path}', 'rb'))['input']]"
+
+        # Path is None. Generate inputs from scratch.
+        tensor_text = []
+        for at in self.input_like.values():
+            tensor_text.append(f"np.zeros({at.shape}, dtype={at.dtype})")
+
+        return f"inp_name = [{', '.join(tensor_text)}]"
+
+    def emit_weight(self, mod_name: str, path: Optional[PathLike] = None):
+        if path is None:
+            return "# No specific weights to load. Just let it self-initialize."
+
+        return f"{mod_name}.load_state_dict(torch.load('{path}'), strict=False)"
+
+    def emit_def(self, mod_name: str, mod_cls: str) -> str:
+        with FxTracing():
+            traced = fx.symbolic_trace(self.native_model)
+
+        tab = " " * 4
+        mod_text = ""
+        for name, param in self.native_model._parameters.items():
+            mod_text += f"{2*tab}self.{name} = torch.nn.Parameter(torch.empty({list(param.shape)}, dtype={param.dtype})))"
+
+        for name, mod in self.native_model.named_children():
+            if name == "":
+                continue
+            mod_text += f"{2*tab}self.{name} = {_render_constructor(name, mod)}\n"
+
+        # fwd code is `traced.code` with 2 tabs in front of each line
+        fwd_code = tab + ("\n" + tab).join(traced.code.strip().splitlines())
+
+        return f"""class {mod_cls}(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+{mod_text}
+{fwd_code}
+
+{mod_name} = {mod_cls}()
+"""
 
     @staticmethod
     def add_seed_setter() -> None:

--- a/nnsmith/materialize/torch/forward.py
+++ b/nnsmith/materialize/torch/forward.py
@@ -1,7 +1,7 @@
 # operator will be used in `eval` later.
 import operator  # noqa: F401
 from functools import partial
-from typing import Callable, Type
+from typing import Type
 
 import torch
 import torch.utils._pytree as pytree
@@ -53,17 +53,8 @@ def forward_fn(op: ConcreteOp):
 
 @operator_impl(Constant)
 def forward_fn(op: Constant):
-    class ConstFn(torch.nn.Module):
-        def __init__(self, data: torch.Tensor) -> None:
-            super().__init__()
-            self.data = torch.nn.parameter.Parameter(
-                data, requires_grad=data.is_floating_point()
-            )
-
-        def forward(self):
-            return self.data
-
-    return ConstFn(torch.randn(op.abs_tensor.shape).to(op.abs_tensor.dtype.torch()))
+    data = torch.randn(op.abs_tensor.shape).to(op.abs_tensor.dtype.torch())
+    return torch.nn.Parameter(data, requires_grad=data.is_floating_point())
 
 
 @operator_impl(ReLU)
@@ -78,7 +69,7 @@ def forward_fn(op: GELU):
 
 @operator_impl(LeakyReLU)
 def forward_fn(op: LeakyReLU):
-    return torch.nn.LeakyReLU(0.01)
+    return torch.nn.functional.leaky_relu
 
 
 @operator_impl(PReLU)
@@ -241,7 +232,7 @@ def forward_fn(op: Neg):
 
 @operator_impl(Softmax)
 def forward_fn(op: Softmax):
-    return torch.nn.Softmax(dim=op.dim)
+    return lambda x: torch.softmax(x, dim=op.dim)
 
 
 @operator_impl(MaxPool2d)
@@ -256,7 +247,7 @@ def forward_fn(op: MaxPool2d):
 @operator_impl(AvgPool2d)
 def forward_fn(op: AvgPool2d):
     return torch.nn.AvgPool2d(
-        kernel_size=(op.kernel_h_size, op.kernel_w_size),
+        kernel_size=(op.kh, op.kw),
         stride=op.stride,
         padding=op.padding,
     )

--- a/nnsmith/materialize/torch/symbolnet.py
+++ b/nnsmith/materialize/torch/symbolnet.py
@@ -121,20 +121,18 @@ class SymbolNet(nn.Module):
 
         self.proxy_enabled_ = False
 
-        # keep track of layers and weights so that the tracing can work properly
-        self.mlist = nn.ModuleList()
         # whether or not to register intermediate tensors as output tensors. Useful (at least) for checking nan
         self.record_intermediate = record_intermediate
         self._device = None
 
         self.ir = ir
 
-        for inst in self.ir.insts:
+        for i, inst in enumerate(self.ir.insts):
             if not isinstance(inst.iexpr.op, Input):
                 torch_fn = forward_fn(inst.iexpr.op)
                 SanityCheck.true(torch_fn is not None, f"Bad impl for {inst.iexpr.op}")
                 if isinstance(torch_fn, nn.Module):
-                    self.mlist.append(torch_fn)
+                    self.add_module(f"m{i}", torch_fn)
                 self.instructions.append(
                     (torch_fn, inst.iexpr.args, inst.retvals(), inst.iexpr.op)
                 )

--- a/nnsmith/narrow_spec.py
+++ b/nnsmith/narrow_spec.py
@@ -70,7 +70,7 @@ def _make_single_op_irs(
         inputs = []
 
         for ishape, idtype in zip(ishapes, idtype_group):
-            input_op = Placeholder(AbsTensor(ishape, idtype)).as_input()
+            input_op = Placeholder(AbsTensor(ishape, idtype)).input()
             inst = ir.add_inst(InstExpr(op=input_op, args=[]))
             inputs.append(inst.retval())
 

--- a/nnsmith/narrow_spec.py
+++ b/nnsmith/narrow_spec.py
@@ -70,7 +70,7 @@ def _make_single_op_irs(
         inputs = []
 
         for ishape, idtype in zip(ishapes, idtype_group):
-            input_op = Placeholder(AbsTensor(ishape, idtype)).to_input()
+            input_op = Placeholder(AbsTensor(ishape, idtype)).as_input()
             inst = ir.add_inst(InstExpr(op=input_op, args=[]))
             inputs.append(inst.retval())
 

--- a/tests/torch/test_render.py
+++ b/tests/torch/test_render.py
@@ -1,0 +1,228 @@
+import pytest
+import torch
+from torch import nn
+
+from nnsmith.abstract import AbsTensor, AvgPool2d, DType
+from nnsmith.gir import GraphIR, InstExpr, Placeholder
+from nnsmith.materialize.torch import TorchModelCPU
+
+
+# CV model
+def test_model_def_clean0():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 3, 3)
+            self.linear = nn.Linear(3, 3)
+            self.bn = nn.BatchNorm2d(3)
+
+        def forward(self, x):
+            x = self.conv(x)
+            x = self.linear(x)
+            x = self.bn(x)
+            return x
+
+    model = TorchModelCPU()
+    model.torch_model = M()
+
+    assert (
+        model.emit_def(mod_name="m", mod_cls="M")
+        == R"""class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 3, kernel_size=(3, 3), stride=(1, 1))
+        self.linear = torch.nn.Linear(in_features=3, out_features=3, bias=True)
+        self.bn = torch.nn.BatchNorm2d(3, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
+
+    def forward(self, x):
+        conv = self.conv(x);  x = None
+        linear = self.linear(conv);  conv = None
+        bn = self.bn(linear);  linear = None
+        return bn
+
+m = M()
+"""
+    )
+
+
+# RNN model
+def test_model_def_clean1():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lstm = nn.LSTM(3, 3)
+            self.linear = nn.Linear(3, 3)
+
+        def forward(self, x):
+            x = self.lstm(x)
+            x = self.linear(x)
+            return x
+
+    model = TorchModelCPU()
+    model.torch_model = M()
+
+    assert (
+        model.emit_def(mod_name="m", mod_cls="M")
+        == R"""class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lstm = torch.nn.LSTM(3, 3)
+        self.linear = torch.nn.Linear(in_features=3, out_features=3, bias=True)
+
+    def forward(self, x):
+        lstm = self.lstm(x);  x = None
+        linear = self.linear(lstm);  lstm = None
+        return linear
+
+m = M()
+"""
+    )
+
+
+# Transformer model
+def test_model_def_clean2():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.attention0 = nn.MultiheadAttention(3, 3)
+            self.attention1 = nn.MultiheadAttention(3, 3)
+            self.linear = nn.Linear(3, 3)
+
+        def forward(self, x):
+            x = self.attention0(x, x, x)
+            x = self.attention1(x, x, x)
+            x = self.linear(x)
+            return x
+
+    model = TorchModelCPU()
+    model.torch_model = M()
+
+    assert (
+        model.emit_def(mod_name="m", mod_cls="M")
+        == R"""class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attention0 = torch.nn.MultiheadAttention(embed_dim=3, num_heads=3, kdim=3, vdim=3)
+        self.attention1 = torch.nn.MultiheadAttention(embed_dim=3, num_heads=3, kdim=3, vdim=3)
+        self.linear = torch.nn.Linear(in_features=3, out_features=3, bias=True)
+
+    def forward(self, x):
+        attention0 = self.attention0(x, x, x);  x = None
+        attention1 = self.attention1(attention0, attention0, attention0);  attention0 = None
+        linear = self.linear(attention1);  attention1 = None
+        return linear
+
+m = M()
+"""
+    )
+
+
+def test_model_def_seq():
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.seq = nn.Sequential(
+                nn.Conv2d(3, 3, 3),
+                nn.Linear(3, 3),
+                nn.BatchNorm2d(3),
+            )
+
+        def forward(self, x):
+            return self.seq(x)
+
+    model = TorchModelCPU()
+    model.torch_model = M()
+
+    assert (
+        model.emit_def(mod_name="m", mod_cls="M")
+        == R"""class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = torch.load('seq.pth') # Sequential
+
+    def forward(self, x):
+        seq_0 = getattr(self.seq, "0")(x);  x = None
+        seq_1 = getattr(self.seq, "1")(seq_0);  seq_0 = None
+        seq_2 = getattr(self.seq, "2")(seq_1);  seq_1 = None
+        return seq_2
+
+m = M()
+"""
+    )
+
+
+def test_model_def_mod_dict():
+    class M(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mod_dict = torch.nn.ModuleDict(
+                {
+                    "conv": torch.nn.Conv2d(3, 3, 3),
+                    "linear": torch.nn.Linear(3, 3),
+                    "bn": torch.nn.BatchNorm2d(3),
+                }
+            )
+
+        def forward(self, x):
+            x = self.mod_dict.conv(x)
+            x = self.mod_dict.linear(x)
+            x = self.mod_dict.bn(x)
+            return x
+
+    model = TorchModelCPU()
+    model.torch_model = M()
+
+    assert (
+        model.emit_def(mod_name="m", mod_cls="M")
+        == R"""class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mod_dict = torch.load('mod_dict.pth') # ModuleDict
+
+    def forward(self, x):
+        mod_dict_conv = self.mod_dict.conv(x);  x = None
+        mod_dict_linear = self.mod_dict.linear(mod_dict_conv);  mod_dict_conv = None
+        mod_dict_bn = self.mod_dict.bn(mod_dict_linear);  mod_dict_linear = None
+        return mod_dict_bn
+
+m = M()
+"""
+    )
+
+
+def test_model_def_nnsmith():
+    ir = GraphIR()
+    ir.add_inst(
+        InstExpr(
+            AvgPool2d(kh=3, kw=3, stride=3, padding=2),
+            [
+                ir.add_inst(
+                    InstExpr(
+                        Placeholder(
+                            ttype=AbsTensor(shape=[1, 3, 64, 64], dtype=DType.float32)
+                        ).as_input(),
+                        [],
+                    )
+                ).retval()
+            ],
+        )
+    )
+
+    model = TorchModelCPU.from_gir(ir)
+
+    assert (
+        model.emit_def(mod_name="m", mod_cls="M")
+        == R"""class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.m1 = torch.nn.AvgPool2d(kernel_size=(3, 3), stride=3, padding=2)
+
+    def forward(self, *args):
+        _args = args
+        getitem = _args[0];  _args = None
+        m1 = self.m1(getitem);  getitem = None
+        return (m1,)
+
+m = M()
+"""
+    )

--- a/tests/torch/test_render.py
+++ b/tests/torch/test_render.py
@@ -199,8 +199,8 @@ def test_model_def_nnsmith():
                 ir.add_inst(
                     InstExpr(
                         Placeholder(
-                            ttype=AbsTensor(shape=[1, 3, 64, 64], dtype=DType.float32)
-                        ).as_input(),
+                            ttype=AbsTensor([1, 3, 64, 64], DType.float32)
+                        ).input(),
                         [],
                     )
                 ).retval()


### PR DESCRIPTION
This PR aims at enabling synthesizing a test case as a bug report so that we can quickly check and report the bugs.

**Stats: impl and testing**
- [x] Codegen for model def
- [x] Codegen for eager exec
- [x] Codegen for compile
- [x] Codegen for compiled run
- [x] Codegen for oracle
- [x] Support PT2
- [ ] Support TorchJIT

**Limitation**
1. Only works for PT.
2. For `nn.Module`, the codegen of constructors might not be correct (but should work for the majority of cases). 
3. Cannot rematerialize `nn.ModuleList`,`nn.ModuleDict`, etc so as a fallback use pickle serialization as a dirty workaround (learnt from `GraphModule.to_folder`.

**Why not just use `GraphModule.to_folder`.** It has no backward compatibility guarantee and has to generate a folder to dump the module which cannot be put together as a single file. It also is too obscure that we don't have customized control if we just ship that. In addition, its support of `nn.Module` is very limited. To systematically support codegen, we have to do that by ourselves.

**What's next** 
1. Specifically find and support more `nn.Module` without proper `repr`. 
2. Support `ONNXModel`