### PR TITLE
Optimize test saving by disabling graphviz

### DIFF
--- a/nnsmith/cli/fuzz.py
+++ b/nnsmith/cli/fuzz.py
@@ -236,7 +236,9 @@ class FuzzingLoop:
                     self.save_test, f"{time.time() - start_time:.3f}"
                 )
                 mkdir(testcase_dir)
+                tmp, testcase.model.dotstring = testcase.model.dotstring, None
                 testcase.dump(testcase_dir)
+                testcase.model.dotstring = tmp
                 time_stat["save"] = time.time() - save_start
 
             FUZZ_LOG.info(

--- a/nnsmith/materialize/__init__.py
+++ b/nnsmith/materialize/__init__.py
@@ -101,6 +101,9 @@ MT = TypeVar("MT", bound="Model")
 
 
 class Model(ABC):
+    def __init__(self):
+        self.dotstring: Optional[str] = None
+
     @property
     @abstractmethod
     def input_like(self) -> Dict[str, AbsTensor]:
@@ -259,7 +262,7 @@ class TestCase:
         return TestCase(model, oracle)
 
     def dump(self, root_folder: str):
-        if self.model and hasattr(self.model, "dotstring"):
+        if self.model and self.model.dotstring:
             self.model.dump_viz(os.path.join(root_folder, "graph.png"))
 
         self.model.dump(


### PR DESCRIPTION
Generating image to visualize NN structures turns out to be costly with `graphviz`. We should have it disabled when saving fuzzing tests for evaluation. Nonetheless, the image gen for rendering bug reports are still there and one should be able to add the image rendering real quick.

Thanks, @Co1lin for the troubleshooting!