### PR TITLE
fix(render): nn.Parameter codegen 

### DIFF
--- a/nnsmith/materialize/torch/__init__.py
+++ b/nnsmith/materialize/torch/__init__.py
@@ -222,10 +222,13 @@ class TorchModel(Model, ABC):
 
         tab = " " * 4
         mod_text = ""
-        for name, param in self.native_model.named_parameters():
+        # _parameters only shows the upper-level parameters
+        # while
+        # named_parameters() shows all parameters recursively
+        for name, param in self.native_model._parameters.items():
             mod_text += (
                 f"{2*tab}self.{name} = torch.nn.Parameter"
-                + f"(torch.empty({list(param.shape)}, dtype={param.dtype}), requires_grad={param.requires_grad})"
+                + f"(torch.empty({list(param.shape)}, dtype={param.dtype}), requires_grad={param.requires_grad})\n"
             )
 
         for name, mod in self.native_model.named_children():

--- a/nnsmith/materialize/torch/__init__.py
+++ b/nnsmith/materialize/torch/__init__.py
@@ -117,10 +117,10 @@ class TorchModel(Model, ABC):
             for name, output in zip(self.output_like.keys(), outputs):
                 output_dict[name] = numpify(output)
                 if output.requires_grad:
-                    # get Vector-Jacobian Product (VJP)
+                    # Get Vector-Jacobian Product (VJP)
                     out_grad = torch.autograd.grad(
                         outputs=output,
-                        inputs=params.values(),
+                        inputs=self.torch_model.parameters(),
                         grad_outputs=torch.ones_like(output),
                         retain_graph=True,
                         allow_unused=True,

--- a/nnsmith/materialize/torch/__init__.py
+++ b/nnsmith/materialize/torch/__init__.py
@@ -222,8 +222,11 @@ class TorchModel(Model, ABC):
 
         tab = " " * 4
         mod_text = ""
-        for name, param in self.native_model._parameters.items():
-            mod_text += f"{2*tab}self.{name} = torch.nn.Parameter(torch.empty({list(param.shape)}, dtype={param.dtype})))"
+        for name, param in self.native_model.named_parameters():
+            mod_text += (
+                f"{2*tab}self.{name} = torch.nn.Parameter"
+                + f"(torch.empty({list(param.shape)}, dtype={param.dtype}), requires_grad={param.requires_grad})"
+            )
 
         for name, mod in self.native_model.named_children():
             if name == "":

--- a/nnsmith/materialize/torch/symbolnet.py
+++ b/nnsmith/materialize/torch/symbolnet.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Dict, Optional
 
 import torch
+import torch.fx as fx
 from torch import nn
 
 from nnsmith.abstract.dtype import DType
@@ -22,7 +23,7 @@ __INPUT_FOUND_INF_MSG__ = "[Inf] in model inputs!"
 __ENABLE_RT_CHECK__ = os.getenv("NNSMITH_RT_CHECK", "0") == "1"
 
 
-# Probablistically, sampling at positive domain is beneficial.
+# Probabilistically, sampling at positive domain is beneficial.
 def random_tensor(shape, dtype: torch.dtype, margin=4, base=5, use_cuda=False):
     # center: -margin ~ 0 ~ +margin
     dev = torch.device("cuda" if use_cuda else "cpu")
@@ -345,9 +346,7 @@ class SymbolNet(nn.Module):
     def forward(self, *args):
         self.differentiable = True
 
-        tensor_map: Dict[str, torch.Tensor] = {
-            k: v for k, v in self._parameters.items()
-        }
+        tensor_map: Dict[str, torch.Tensor] = {k: v for k, v in self.named_parameters()}
         for i, key in enumerate(self.input_map.keys()):
             tensor_map[key] = args[i]
 
@@ -359,8 +358,9 @@ class SymbolNet(nn.Module):
             check_type(op, input_tensors, is_input=True, msg="input")
 
             # REAL FORWARD.
+            print(inst, input_tensors)
             output_tensors = inst(*input_tensors)
-            if isinstance(output_tensors, torch.fx.proxy.Proxy):
+            if isinstance(output_tensors, fx.proxy.Proxy):
                 # TODO(@ganler, @co1lin): can we do systematic check through the output type?
                 if output_tensors.node.target not in [torch.split, torch.chunk]:
                     output_tensors = [output_tensors]
@@ -382,9 +382,7 @@ class SymbolNet(nn.Module):
     def forward_grad(self, *args):
         self.differentiable = True
 
-        tensor_map: Dict[str, torch.Tensor] = {
-            k: v for k, v in self._parameters.items()
-        }
+        tensor_map: Dict[str, torch.Tensor] = {k: v for k, v in self.named_parameters()}
         for i, key in enumerate(self.input_map.keys()):
             tensor_map[key] = args[i]
 

--- a/nnsmith/materialize/torch/symbolnet.py
+++ b/nnsmith/materialize/torch/symbolnet.py
@@ -346,7 +346,7 @@ class SymbolNet(nn.Module):
     def make_param_map(self) -> Dict[str, torch.Tensor]:
         tensor_map: Dict[str, torch.Tensor] = {}
 
-        for k, v in self.named_parameters():
+        for k, v in self._parameters.items():
             # Workaround: https://github.com/ise-uiuc/nnsmith/pull/122
             if hasattr(self, k):
                 attr = getattr(self, k)


### PR DESCRIPTION
Fix #121. The codegen for `nn.Parameter`:
1. removed an extra right bracket
2. explicitly specified `requires_grad=` in generated code 
3. used object attr to reference `nn.Parameter` instead of relying on `named_parameters()`