### PR TITLE
fix: update at-style pip fragment annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 **Install latest code (GitHub HEAD):**
 
 ```shell
-pip install "git+https://github.com/ise-uiuc/nnsmith@main#egg=nnsmith[torch,onnx]" --upgrade
+pip install pip --upgrade
+pip install "nnsmith[torch,onnx] @ git+https://github.com/ise-uiuc/nnsmith@main" --upgrade
 # [optional] add more front- and back-ends such as [tensorflow] and [tvm,onnxruntime,...] in "[...]"
 ```
 

--- a/requirements/sys/tensorflow.txt
+++ b/requirements/sys/tensorflow.txt
@@ -1,3 +1,4 @@
 tf-nightly
 # NOTE: https://www.tensorflow.org/install
 # https://www.tensorflow.org/install/pip
+requests # a limitation of tensorflow dependency


### PR DESCRIPTION
This resolves pip install warning but may require a more recent pip version.
See also: https://github.com/pypa/pip/pull/11617